### PR TITLE
[bugfix] layer ordering

### DIFF
--- a/src/components/map/default-layers.js
+++ b/src/components/map/default-layers.js
@@ -163,7 +163,8 @@ export const DefaultLayers = () => {
     return (
         <>
         {defaultModelLayers
-            .filter(({state }) => state.visible)
+            .filter(({state}) => state.visible)
+            .reverse()
             .map((layer, index) => {
                 const pieces = layer.id.split('-');
                 const type = pieces[pieces.length-1];
@@ -172,21 +173,16 @@ export const DefaultLayers = () => {
                     //console.log("obsData: " + JSON.stringify(obsData, null, 2));
                     return (
                         <GeoJSON
-                            key = {index}
-                            data = {obsData}
-                            pointToLayer = {obsPointToLayer}
-                            onEachFeature = {onEachObsFeature}
+                            key={`${index}-${layer.id}`}
+                            data={obsData}
+                            pointToLayer={obsPointToLayer}
+                            onEachFeature={onEachObsFeature}
                         />
                     );
                 } else {
                     return (
                         <WMSTileLayer
-                            key = {index}
-                            /* eventHandlers={{
-                                click: () => {
-                                console.log('marker clicked')
-                                },
-                            }} */
+                            key={`${index}-${layer.id}`}
                             url={gs_wms_url}
                             layers={layer.layers}
                             params={{


### PR DESCRIPTION
@lstillwe you observed a layer-ordering anomaly on May 8 in Slack; this PR aims to address that issue.

it seems that when the user reorders layers, the `defaultModelLayers` ordering updates in state as expected, but the layers don't get updated on the map.

as we know, we can force rerendering a component by manually changing its `key` prop. the `key` prop on those layer components was simply the index in the map/array traversal, which seemed sufficient to rerender things and keep them in sync. however, it was not. but it seems that adding a piece of data from the layer to the `key` seems to keep state and layers on the map in sync.

also, i think we were rendering them in the opposite stacking order. please verify! :grin: 