### PR TITLE
Capture/display a share comment.

### DIFF
--- a/src/components/dialog/observation-dialog.js
+++ b/src/components/dialog/observation-dialog.js
@@ -32,7 +32,7 @@ export const ObservationDialog = (obs_data) => {
     const floaterArgs = {
         title: obs_data.obs['location_name'],
         dialogObject: {...graphObj(obs_data.obs['csvurl'])},
-        dataKey: obs_data.obs['station_name'],
+        dataKey: obs_data.obs['id'],
         dataList: selectedObservations,
         setDataList: setSelectedObservations,
         map: map

--- a/src/components/dialog/observation-dialog.js
+++ b/src/components/dialog/observation-dialog.js
@@ -32,7 +32,7 @@ export const ObservationDialog = (obs_data) => {
     const floaterArgs = {
         title: obs_data.obs['location_name'],
         dialogObject: {...graphObj(obs_data.obs['csvurl'])},
-        dataKey: obs_data.obs['id'],
+        dataKey: obs_data.obs['station_name'],
         dataList: selectedObservations,
         setDataList: setSelectedObservations,
         map: map

--- a/src/components/map/default-layers.js
+++ b/src/components/map/default-layers.js
@@ -27,16 +27,6 @@ export const DefaultLayers = () => {
     const [obsData, setObsData] = useState("");
     const map = useMap();
 
-    // get the hash location (if any)
-    const { hash } = useLocation();
-
-    let share_run = '';
-
-    if (hash !== '') {
-        share_run = '&run_id=' + hash.split('=')[1];
-        share_run = share_run.split(',')[0];
-    }
-
     const {
         defaultModelLayers,
         setDefaultModelLayers,
@@ -97,8 +87,29 @@ export const DefaultLayers = () => {
         }
     };
 
+    // get the hash location from the URL (if any)
+    const { hash } = useLocation();
+
+    // init the run id used for targeted data gathering
+    let run_id = '';
+
+    // if we got a hash link strip it out and use it in the data gathering URL
+    if (hash !== '') {
+        // get the payload
+        let payload = hash.split('=')[1];
+
+        // split the payload into run id and comment
+        payload = payload.split(',');
+
+        // did we get a valid payload?
+        if (payload.length === 2) {
+            // get the run id
+            run_id = '&run_id=' + payload[0];
+        }
+    }
+
     // create the URLs to the data endpoints
-    const data_url = `${process.env.REACT_APP_UI_DATA_URL}get_ui_data_secure?limit=1&use_new_wb=true&use_v3_sp=true` + share_run;
+    const data_url = `${process.env.REACT_APP_UI_DATA_URL}get_ui_data_secure?limit=1&use_new_wb=true&use_v3_sp=true${run_id}`;
     const gs_wms_url = `${process.env.REACT_APP_GS_DATA_URL}wms`;
     const gs_wfs_url = `${process.env.REACT_APP_GS_DATA_URL}`;
 

--- a/src/components/share/buildlink.js
+++ b/src/components/share/buildlink.js
@@ -1,7 +1,8 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
+import { Button, TextField, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { IconButton } from '@mui/joy';
 import ShareRoundedIcon from '@mui/icons-material/ShareRounded';
-import {useLayers} from "@context/map-context";
+import { useLayers } from "@context/map-context";
 
 /**
  * renders the link builder to recreate the current view elsewhere
@@ -10,13 +11,16 @@ import {useLayers} from "@context/map-context";
  * @constructor
  */
 export const BuildLink = () => {
-    // get the layers in state
+    // get the layers from state
     const { defaultModelLayers } = useLayers();
+
+    // used to set the dialog view state
+    const [open, setOpen] = useState(false);
 
     /**
      * create the query string that can be used to share the current view
      */
-    const createLink = () => {
+    const createLink = (comment) => {
         // get the list of selected layers
         const groups = defaultModelLayers
             // get all the distinct groups
@@ -26,16 +30,13 @@ export const BuildLink = () => {
             .map((mbr) => (
                 mbr['group']
             ))
-            // generate a query string
-            .join(',');
+            // generate a run id
+            .join(',').split(',')[0];
 
         // check to see if there was one or more groups selected
         if (groups !== '') {
             // copy the link to the cut/paste buffer
-            copyTextToClipboard(window.location.origin + '/#share=' + groups).then();
-
-            // tell the user what just happened
-            alert('The share link has been copied to the clipboard.');
+            copyTextToClipboard(encodeURI(window.location.origin + '/#share=' + groups + ',' + comment)).then();
         }
         // no layers were selected on the map
         else
@@ -53,12 +54,47 @@ export const BuildLink = () => {
         return await navigator.clipboard.writeText(text);
     }
 
-    // render the button
+    // handles the dialog open event
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    // handles the dialog close event
+    const handleClose = () => {
+        setOpen(false);
+    };
+
     return (
         <Fragment>
-            <IconButton onClick={ createLink }>Share&nbsp;
+            <IconButton onClick={handleClickOpen}>Share&nbsp;
                 <ShareRoundedIcon color={'primary'} />
             </IconButton>
+            <Dialog
+                open={ open }
+                onClose={ handleClose }
+                PaperProps={{
+                    component: 'form',
+                    onSubmit: (event) => {
+                        event.preventDefault();
+                        const formData = new FormData(event.currentTarget);
+                        const formJson = Object.fromEntries(formData.entries());
+                        const comment = formJson.comment;
+                        createLink(comment);
+                        handleClose();
+                    }}}>
+                <DialogTitle>Share this view</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Please enter a comment below that describes what you are sharing. When ready, select the &quot;Create&quot; button
+                        and you will have the share link copied into your cut/paste buffer.
+                    </DialogContentText>
+                    <TextField autoFocus margin="dense" id="comment" name="comment" fullWidth variant="standard"/>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>Cancel</Button>
+                    <Button type="submit">Create</Button>
+                </DialogActions>
+            </Dialog>
         </Fragment>
     );
 };

--- a/src/components/share/buildlink.js
+++ b/src/components/share/buildlink.js
@@ -29,18 +29,14 @@ export const BuildLink = () => {
             // return the group name
             .map((mbr) => (
                 mbr['group']
-            ))
-            // generate a run id
-            .join(',').split(',')[0];
+            )).join(',').split(',')[0];
 
         // capture the selected observations from state
         const observations = selectedObservations.map(
             (x) => (
                 JSON.stringify({'id': x.id, 'lat': x.lat, 'lng': x.lon, 'location_name': x.location_name, 'station_name': x.station_name, 'csvurl': x.csvurl})
             )
-        )
-        // generate a query string
-        .join(',');
+        ).join(',');
 
         // check to see if there was one or more groups selected
         if (run_id !== '') {

--- a/src/components/share/buildlink.js
+++ b/src/components/share/buildlink.js
@@ -12,7 +12,7 @@ import { useLayers } from "@context/map-context";
  */
 export const BuildLink = () => {
     // get the layers from state
-    const { defaultModelLayers } = useLayers();
+    const { defaultModelLayers, selectedObservations } = useLayers();
 
     // used to set the dialog view state
     const [open, setOpen] = useState(false);
@@ -21,8 +21,8 @@ export const BuildLink = () => {
      * create the query string that can be used to share the current view
      */
     const createLink = (comment) => {
-        // get the list of selected layers
-        const groups = defaultModelLayers
+        // get the list of selected layers from state
+        const run_id = defaultModelLayers
             // get all the distinct groups
             .filter((val, idx, self) =>
                 ( idx === self.findIndex((t)=> ( t['group'] === val['group'] ))))
@@ -33,10 +33,19 @@ export const BuildLink = () => {
             // generate a run id
             .join(',').split(',')[0];
 
+        // capture the selected observations from state
+        const observations = selectedObservations.map(
+            (x) => (
+                JSON.stringify({'id': x.id, 'lat': x.lat, 'lng': x.lon, 'location_name': x.location_name, 'station_name': x.station_name, 'csvurl': x.csvurl})
+            )
+        )
+        // generate a query string
+        .join(',');
+
         // check to see if there was one or more groups selected
-        if (groups !== '') {
+        if (run_id !== '') {
             // copy the link to the cut/paste buffer
-            copyTextToClipboard(encodeURI(window.location.origin + '/#share=' + groups + ',' + comment)).then();
+            copyTextToClipboard(encodeURI(window.location.origin + '/#share=run_id:' + run_id + "~comment=" + comment + '~obs=[' + observations + ']')).then();
         }
         // no layers were selected on the map
         else

--- a/src/components/share/share-comment.js
+++ b/src/components/share/share-comment.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Typography, Card } from '@mui/joy';
-import { useLocation } from "react-router-dom";
+import { parseSharedURL } from "@utils/map-utils";
 
 /**
  * renders the shared content on the app as defined in the query string
@@ -9,36 +9,18 @@ import { useLocation } from "react-router-dom";
  * @constructor
  */
 export const ShareComment = () => {
-
-    // get the hash location (if any)
-    const { hash } = useLocation();
-
-    // decompose the hash link
-    let comment = '';
-
-    // if we got a hash link
-    if (hash !== '') {
-        // get the payload
-        let payload = hash.split('=')[1];
-
-        // split the payload into run id and comment
-        payload = payload.split(',');
-
-        // did we get a valid payload
-        if (payload.length === 2) {
-            // get the comment
-            comment = decodeURI(payload[1]);
-        }
-    }
+    // parse the hash of the sharing URL
+    const shared_params = parseSharedURL();
 
     // if there was a comment, display it
-    if (comment !== '') {
+    if ( shared_params['comment'] !== '') {
         return (
             <Card variant="outlined" sx={{maxWidth: '100%'}}>
-                <Typography sx={{ wordBreak: "break-word" }} color={"primary"}>Share comment: {comment}</Typography>
+                <Typography sx={{ wordBreak: "break-word" }} color={"primary"}>Share comment: { shared_params['comment']}</Typography>
             </Card>
         );
     }
     else
+        // return nothing (basically)
         return ( <Fragment></Fragment> );
 };

--- a/src/components/share/share-comment.js
+++ b/src/components/share/share-comment.js
@@ -1,0 +1,44 @@
+import React, { Fragment } from 'react';
+import { Typography, Card } from '@mui/joy';
+import { useLocation } from "react-router-dom";
+
+/**
+ * renders the shared content on the app as defined in the query string
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export const ShareComment = () => {
+
+    // get the hash location (if any)
+    const { hash } = useLocation();
+
+    // decompose the hash link
+    let comment = '';
+
+    // if we got a hash link
+    if (hash !== '') {
+        // get the payload
+        let payload = hash.split('=')[1];
+
+        // split the payload into run id and comment
+        payload = payload.split(',');
+
+        // did we get a valid payload
+        if (payload.length === 2) {
+            // get the comment
+            comment = decodeURI(payload[1]);
+        }
+    }
+
+    // if there was a comment, display it
+    if (comment !== '') {
+        return (
+            <Card variant="outlined" sx={{maxWidth: '100%'}}>
+                <Typography sx={{ wordBreak: "break-word" }} color={"primary"}>Share comment: {comment}</Typography>
+            </Card>
+        );
+    }
+    else
+        return ( <Fragment></Fragment> );
+};

--- a/src/components/trays/layers/tray-contents.js
+++ b/src/components/trays/layers/tray-contents.js
@@ -6,6 +6,7 @@ import {
 } from '@mui/icons-material';
 import { LayersList } from './list';
 import { AddLayerForm } from './form';
+import { ShareComment } from '@share/share-comment';
 
 const FORM = 'FORM';
 const LIST = 'LIST';
@@ -52,7 +53,9 @@ export const TrayContents = () => {
       '.MuiListItem-root': { my: 1 },
     }}>
       { state === LIST && <LayersList /> }
-      
+
+        <ShareComment/>
+
       { state === FORM && <AddLayerForm /> }
 
       <TrayFooter />

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -4,7 +4,6 @@ import locationIcon from '@images/location_searching_FILL0_wght400_GRAD0_opsz24.
 import USGSTopo from '@images/basemaps/USGS-US-Topo.png';
 import USGSImagery from '@images/basemaps/USGS-US-Imagery.png';
 import CartoDBPositron from '@images/basemaps/CartoDB-Positron.png';
-
 import { useLocation } from "react-router-dom";
 
 // function to add a location marker where ever and obs mod layer
@@ -62,13 +61,13 @@ export const parseSharedURL = () => {
         // did we get a valid payload?
         if (payload.length === 3) {
             // get the run id. this is used on another data query string so add the param
-            run_id = (payload[0].split('run_id:')[1] !== undefined) ? '&run_id=' + payload[0].split('run_id:')[1] : '';
+            run_id = (payload[0].split('run_id:')[1] !== undefined && payload[0].split('run_id:')[1] !== '') ? '&run_id=' + payload[0].split('run_id:')[1] : '';
 
             // get the comment
-            comment = (payload[1].split('comment=')[1] !== undefined) ? decodeURI(payload[1].split('comment=')[1]) : '';
+            comment = (payload[1].split('comment=')[1] !== undefined && payload[1].split('comment=')[1] !== '') ? decodeURI(payload[1].split('comment=')[1]) : '';
 
             // get the selected observations
-            obs = (payload[2].split('obs=')[1] !== undefined) ? JSON.parse(decodeURI(payload[2].split('obs=')[1])) : '';
+            obs = (payload[2].split('obs=')[1] !== undefined && payload[2].split('obs=')[1] !== '') ? JSON.parse(decodeURI(payload[2].split('obs=')[1])) : '';
         }
     }
 

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -5,6 +5,7 @@ import USGSTopo from '@images/basemaps/USGS-US-Topo.png';
 import USGSImagery from '@images/basemaps/USGS-US-Imagery.png';
 import CartoDBPositron from '@images/basemaps/CartoDB-Positron.png';
 
+import { useLocation } from "react-router-dom";
 
 // function to add a location marker where ever and obs mod layer
 // feature is clicked icon downloaded as png from here: 
@@ -38,6 +39,59 @@ export const markUnclicked = (map, id) => {
       }
     }
   });
+};
+
+/**
+ * parses the hash section of the url used for sharing
+ *
+ */
+export const parseSharedURL = () => {
+    // get the hash location from the URL (if any)
+    const { hash } = useLocation();
+
+    // init the return variables
+    let run_id = '';
+    let comment = '';
+    let obs = '';
+
+    // if there was a hash code
+    if (hash !== '') {
+        // get the hash payload
+        const payload = hash.split('~');
+
+        // did we get a valid payload?
+        if (payload.length === 3) {
+            // get the run id. this is used on another data query string so add the param
+            run_id = (payload[0].split('run_id:')[1] !== undefined) ? '&run_id=' + payload[0].split('run_id:')[1] : '';
+
+            // get the comment
+            comment = (payload[1].split('comment=')[1] !== undefined) ? decodeURI(payload[1].split('comment=')[1]) : '';
+
+            // get the selected observations
+            obs = (payload[2].split('obs=')[1] !== undefined) ? JSON.parse(decodeURI(payload[2].split('obs=')[1])) : '';
+        }
+    }
+
+    // return the shared URL to the caller
+    return {'run_id': run_id, 'comment': comment, 'obs': obs};
+};
+
+/**
+ * Adds the observations that come in on the shared query string
+ *
+ * @param map
+ * @param obs
+ * @param setSelectedObservations
+ */
+export const addSharedObservations = (map, obs, setSelectedObservations )=> {
+    // put a target icon on the map and observation data in state
+    obs.forEach(r => {
+        // put the target icons on the map
+        markClicked(map, {'latlng': {'lat': r.lat, 'lng': r.lng}}, r.id);
+
+        // add the selected observation data into state
+        setSelectedObservations(previous => [...previous, r]);
+    });
 };
 
 // add any new basemaps here


### PR DESCRIPTION
Adds a dialog to capture a share comment. also added a control to the layers tray that shows the comment.

This update requires at least 2 steps to test.

Creation of the share link
1. open the app.
2. select one or more observations 
3. hit the share button
4. in the dialog that appears put in a comment
5. then hit the create button.
6. this will have placed a URL in your cut/paste buffer. which you will use for...

Loading the share link
1. paste the url into your browser
2. behold the recreation of your share. including...
- your comment appearing in the "layers" tray.
- any observation dialogs recreated. if you chose >1 you will have to move them because they will overlap.

Here is an example share URL:

http://localhost:8080/#share=run_id:4378-2024041512-gfsforecast~comment=Look%20at%20these%20obs%20from%20the%2015th!~obs=%5B%7B%22id%22:%228454049%22,%22lat%22:41.58694,%22lng%22:-71.41,%22location_name%22:%22Quonset%20Point%22,%22station_name%22:%228454049%22,%22csvurl%22:%22https://apsviz-ui-data.apps.renci.org/get_station_data?station_name=8454049&time_mark=2024-04-17T12:00:00Z&data_source=GFSFORECAST_NCSC_SAB_V1.23&instance_name=ncsc123_gfs_sb55.01&forcing_metclass=synoptic%22%7D,%7B%22id%22:%228518750%22,%22lat%22:40.700556,%22lng%22:-74.014167,%22location_name%22:%22The%20Battery%22,%22station_name%22:%228518750%22,%22csvurl%22:%22https://apsviz-ui-data.apps.renci.org/get_station_data?station_name=8518750&time_mark=2024-04-17T12:00:00Z&data_source=GFSFORECAST_NCSC_SAB_V1.23&instance_name=ncsc123_gfs_sb55.01&forcing_metclass=synoptic%22%7D%5D

if this PR is satisfactory, please merge and remove the branch upon approval.