### PR TITLE
Feature/dialog cascade

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,8 +23,11 @@ const Content = () => {
         <Fragment>
             {
                 // for each observation selected
-                selectedObservations.map (function (obs) {
-                    // render the observation
+                selectedObservations.map (function (obs, idx) {
+                    // add in an index used to cascade the dialogs
+                    obs['index']=idx;
+
+                    // render the observation draggable dialog
                     return <ObservationDialog key={obs["station_name"]} obs={obs} />;
                 })
             }

--- a/src/components/control-panel/control-panel.js
+++ b/src/components/control-panel/control-panel.js
@@ -277,7 +277,7 @@ export const ControlPanel = () => {
         '&:hover': { filter: 'opacity(1.0)' },
         height: 'auto',
         width: '300px',
-        zIndex: 401,
+        zIndex: 410,
         borderRadius: 'sm',
       }}
     >

--- a/src/components/dialog/base-floating-dialog.js
+++ b/src/components/dialog/base-floating-dialog.js
@@ -45,11 +45,8 @@ export default function BaseFloatingDialog({ title, index, dialogObject, dataKey
             // remove the bullseye
             markUnclicked(map, dataKey);
 
-            // recreate the data list
-            const new_data_list = dataList.filter(item => item.id !== dataKey);
-
             // remove this item from the data list
-            setDataList(new_data_list);
+            setDataList(dataList.filter(item => item.id !== dataKey));
         }
     };
 

--- a/src/components/dialog/base-floating-dialog.js
+++ b/src/components/dialog/base-floating-dialog.js
@@ -15,6 +15,7 @@ import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 // define the properties of this component's input
 BaseFloatingDialog.propTypes = {
     title: PropTypes.string,
+    index: PropTypes.any,
     dialogObject: PropTypes.any,
     dataKey: PropTypes.any,
     dataList: PropTypes.any,
@@ -27,13 +28,14 @@ BaseFloatingDialog.propTypes = {
  * Note: this component
  *
  * @param title - the name of the dialog: string
+ * @param index - the index of the data
  * @param dialogObject the object to render in the dialog: {JSX.Element}
  * @param dataKey - the key to the data list elements in state: string
  * @param dataList - a data list in state: array
  * @param setDataList - method to update a data list in state: function
  * @param map - a reference to the map state: object
  */
-export default function BaseFloatingDialog({ title, dialogObject, dataKey, dataList, setDataList, map} ) {
+export default function BaseFloatingDialog({ title, index, dialogObject, dataKey, dataList, setDataList, map} ) {
     /**
     * the close dialog handler
     */
@@ -43,8 +45,11 @@ export default function BaseFloatingDialog({ title, dialogObject, dataKey, dataL
             // remove the bullseye
             markUnclicked(map, dataKey);
 
+            // recreate the data list
+            const new_data_list = dataList.filter(item => item.id !== dataKey);
+
             // remove this item from the data list
-            setDataList(dataList.filter(item => item.id !== dataKey));
+            setDataList(new_data_list);
         }
     };
 
@@ -63,7 +68,8 @@ export default function BaseFloatingDialog({ title, dialogObject, dataKey, dataL
                 disableEnforceFocus
                 style={{ pointerEvents: 'none' }}
                 PaperProps={{ sx: { width: 750,  height: 465, pointerEvents: 'auto' } }}
-                sx={{ zIndex: 402, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' }}}
+                sx={{ zIndex: 402, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
+                        position: 'absolute', left: index * 20, top: index * 43 }}
             >
                 <DialogTitle sx={{ cursor: 'move', backgroundColor: 'lightblue', textAlign: 'center',
                                 fontSize: 14, height: 45, p: 1.5 }} id="draggable-dialog"> { title }
@@ -87,15 +93,19 @@ export default function BaseFloatingDialog({ title, dialogObject, dataKey, dataL
 * @constructor
 */
 function PaperComponent(props) {
+    // create a reference to avoid the findDOMNode deprecation issue
+    const nodeRef = React.useRef(null);
+
+    // render the component
     return (
-        <Draggable  defaultPosition={{x: 0, y: 0 }} handle="#draggable-dialog" cancel={'[class*="MuiDialogContent-root"]'}>
-            <Paper { ...props } />
+        <Draggable nodeRef={nodeRef} handle="#draggable-dialog" cancel={'[class*="MuiDialogContent-root"]'}>
+            <Paper ref={nodeRef} {...props} />
         </Draggable>
     );
 }
 
 /**
-* This creates an animated transition for the dialog that pops up
+ * This creates an animated transition for the dialog that pops up
 *
 * @type {React.ForwardRefExoticComponent<React.PropsWithoutRef<{}> & React.RefAttributes<any>>}
 */

--- a/src/components/dialog/base-floating-dialog.js
+++ b/src/components/dialog/base-floating-dialog.js
@@ -64,8 +64,8 @@ export default function BaseFloatingDialog({ title, index, dialogObject, dataKey
                 TransitionComponent={ Transition }
                 disableEnforceFocus
                 style={{ pointerEvents: 'none' }}
-                PaperProps={{ sx: { width: 750,  height: 465, pointerEvents: 'auto' } }}
-                sx={{ zIndex: 405, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
+                PaperProps={{ sx: { width: 800,  height: 465, pointerEvents: 'auto' } }}
+                sx={{ zIndex: 405, width: 800, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
                         left: index * 20, top: 20 + index * 43 }}
             >
                 <DialogTitle sx={{ cursor: 'move', backgroundColor: 'lightblue', textAlign: 'center',
@@ -76,7 +76,7 @@ export default function BaseFloatingDialog({ title, index, dialogObject, dataKey
                     <CloseOutlinedIcon color={"primary"}/>
                 </IconButton>
 
-                <DialogContent sx={{ backgroundColor: 'white', fontSize: 11, m: 0, width: 590, height: 350 }}>{ dialogObject }</DialogContent>
+                <DialogContent sx={{ backgroundColor: 'white', fontSize: 11, m: 0, width: "100%", height: 350 }}>{ dialogObject }</DialogContent>
             </Dialog>
         </Fragment>
     );

--- a/src/components/dialog/base-floating-dialog.js
+++ b/src/components/dialog/base-floating-dialog.js
@@ -69,7 +69,7 @@ export default function BaseFloatingDialog({ title, index, dialogObject, dataKey
                 style={{ pointerEvents: 'none' }}
                 PaperProps={{ sx: { width: 750,  height: 465, pointerEvents: 'auto' } }}
                 sx={{ zIndex: 402, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
-                        position: 'absolute', left: index * 20, top: index * 43 }}
+                        left: index * 20, top: index * 43 }}
             >
                 <DialogTitle sx={{ cursor: 'move', backgroundColor: 'lightblue', textAlign: 'center',
                                 fontSize: 14, height: 45, p: 1.5 }} id="draggable-dialog"> { title }

--- a/src/components/dialog/base-floating-dialog.js
+++ b/src/components/dialog/base-floating-dialog.js
@@ -65,8 +65,8 @@ export default function BaseFloatingDialog({ title, index, dialogObject, dataKey
                 disableEnforceFocus
                 style={{ pointerEvents: 'none' }}
                 PaperProps={{ sx: { width: 750,  height: 465, pointerEvents: 'auto' } }}
-                sx={{ zIndex: 402, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
-                        left: index * 20, top: index * 43 }}
+                sx={{ zIndex: 405, width: 750, height: 465, '.MuiBackdrop-root': { backgroundColor: 'transparent' },
+                        left: index * 20, top: 20 + index * 43 }}
             >
                 <DialogTitle sx={{ cursor: 'move', backgroundColor: 'lightblue', textAlign: 'center',
                                 fontSize: 14, height: 45, p: 1.5 }} id="draggable-dialog"> { title }

--- a/src/components/dialog/observation-chart.js
+++ b/src/components/dialog/observation-chart.js
@@ -70,12 +70,12 @@ function CreateObsChart(url) {
             { status === 'pending' ? (
                 <div>Loading...</div>
             ) : status === 'error' ? (
-                <div>Error: {error.message}</div>
+                <div>Error: { error.message }</div>
             ) : (
-                <LineChart data={data} margin={{ left: -10 }}>
+                <LineChart data={ data } margin={{ left: -10 }}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="time" allowDuplicatedCategory={ false } />
-                    <YAxis domain={ obsChartY } />
+                    <YAxis tickCount="10" domain={ obsChartY } />
                     <Tooltip />
                     <Legend align={ 'center' } />
                     <Line type="monotone" dataKey="Observations" stroke="black" strokeWidth={2} dot={false} isAnimationActive={false} />

--- a/src/components/dialog/observation-chart.js
+++ b/src/components/dialog/observation-chart.js
@@ -2,6 +2,7 @@ import React from 'react';
 import axios from 'axios';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Legend, ResponsiveContainer, Tooltip } from 'recharts';
 import { useQuery } from '@tanstack/react-query';
+import { useSettings } from "@context";
 
 /**
  * renders the observations as a chart
@@ -57,6 +58,9 @@ function getObsChartData(url) {
  * @constructor
  */
 function CreateObsChart(url) {
+    // get the settings for the Y-axis min/max values
+    const { obsChartY } = useSettings();
+
     // call to get the data. expect back some information too
     const { status, data, error } = getObsChartData(url.url);
 
@@ -70,8 +74,8 @@ function CreateObsChart(url) {
             ) : (
                 <LineChart data={data} margin={{ left: -10 }}>
                     <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="time" allowDuplicatedCategory={false} />
-                    <YAxis domain={['auto', 'auto']}/>
+                    <XAxis dataKey="time" allowDuplicatedCategory={ false } />
+                    <YAxis domain={ obsChartY } />
                     <Tooltip />
                     <Legend align={ 'center' } />
                     <Line type="monotone" dataKey="Observations" stroke="black" strokeWidth={2} dot={false} isAnimationActive={false} />

--- a/src/components/dialog/observation-dialog.js
+++ b/src/components/dialog/observation-dialog.js
@@ -31,6 +31,7 @@ export const ObservationDialog = (obs_data) => {
     // create a data object for the base dialog to use to render
     const floaterArgs = {
         title: obs_data.obs['location_name'],
+        index: obs_data.obs['index'],
         dialogObject: {...graphObj(obs_data.obs['csvurl'])},
         dataKey: obs_data.obs['id'],
         dataList: selectedObservations,

--- a/src/components/dialog/observation-dialog.js
+++ b/src/components/dialog/observation-dialog.js
@@ -23,7 +23,7 @@ export const ObservationDialog = (obs_data) => {
         // create the chart
         return (
             <Fragment>
-                <ObservationChart url={url} />
+                <ObservationChart url={ url } />
             </Fragment>
         );
     };
@@ -32,7 +32,7 @@ export const ObservationDialog = (obs_data) => {
     const floaterArgs = {
         title: obs_data.obs['location_name'],
         index: obs_data.obs['index'],
-        dialogObject: {...graphObj(obs_data.obs['csvurl'])},
+        dialogObject: { ...graphObj(obs_data.obs['csvurl']) },
         dataKey: obs_data.obs['id'],
         dataList: selectedObservations,
         setDataList: setSelectedObservations,
@@ -42,7 +42,7 @@ export const ObservationDialog = (obs_data) => {
     // render the dialog
     return (
         <Fragment>
-            <BaseFloatingDialog {...floaterArgs} />
+            <BaseFloatingDialog { ...floaterArgs } />
         </Fragment>
     );
 };

--- a/src/components/dialog/observation-dialog.js
+++ b/src/components/dialog/observation-dialog.js
@@ -1,6 +1,6 @@
-import React, {Fragment} from 'react';
+import React, { Fragment } from 'react';
 import BaseFloatingDialog from "@dialog/base-floating-dialog";
-import {useLayers} from "@context";
+import { useLayers } from "@context";
 import ObservationChart from "@dialog/observation-chart";
 
 /**

--- a/src/components/legend/legend.js
+++ b/src/components/legend/legend.js
@@ -64,7 +64,7 @@ export const MapLegend = () => {
             height: 'auto',
             width: '100px',
             padding: '10px',
-            zIndex: 401,
+            zIndex: 410,
             borderRadius: 'sm',
             visibility: legendVisibilty,
         }}         

--- a/src/components/map/default-layers.js
+++ b/src/components/map/default-layers.js
@@ -29,7 +29,8 @@ export const DefaultLayers = () => {
     const {
         defaultModelLayers,
         setDefaultModelLayers,
-        setSelectedObservations
+        setSelectedObservations,
+        setShowShareComment
     } = useLayers();
 
     const obsPointToLayer = ((feature, latlng) => {
@@ -147,6 +148,9 @@ export const DefaultLayers = () => {
 
                 // save the observation data
                 setObsData(data);
+
+                // turn on the show comment state
+                setShowShareComment(true);
 
                 // update the selected observations specified on the share link
                 addSharedObservations(map, shared_params['obs'], setSelectedObservations);

--- a/src/components/map/default-layers.js
+++ b/src/components/map/default-layers.js
@@ -71,7 +71,6 @@ export const DefaultLayers = () => {
           layer.on("mouseout", function () {
             this.closePopup();
           });
-
           layer.on("click", function (e) {
             // this id is used to remove a selected observation from the selectedObservations list when the dialog is closed
             feature.properties.id = feature.properties.station_name;
@@ -145,6 +144,8 @@ export const DefaultLayers = () => {
                                 "&typeName=" +
                                 obsLayer.layers;
                 const {data} = await axios.get(obs_url);
+
+                // save the observation data
                 setObsData(data);
 
                 // update the selected observations specified on the share link

--- a/src/components/share/buildlink.js
+++ b/src/components/share/buildlink.js
@@ -22,6 +22,7 @@ export const BuildLink = () => {
      */
     const createLink = (comment) => {
         // get the list of selected layers from state
+        // this forces the group at the top to be the reproduced in the share line
         const run_id = defaultModelLayers
             // get all the distinct groups
             .filter((val, idx, self) =>

--- a/src/components/share/share-comment.js
+++ b/src/components/share/share-comment.js
@@ -1,6 +1,8 @@
 import React, { Fragment } from 'react';
-import { Typography, Card } from '@mui/joy';
-import { parseSharedURL } from "@utils/map-utils";
+import { Typography, Card, IconButton } from '@mui/joy';
+import { parseSharedURL} from "@utils/map-utils";
+import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
+import { useLayers } from "@context";
 
 /**
  * renders the shared content on the app as defined in the query string
@@ -9,14 +11,28 @@ import { parseSharedURL } from "@utils/map-utils";
  * @constructor
  */
 export const ShareComment = () => {
+    // get the show shared comment state
+    const { showShareComment, setShowShareComment } = useLayers();
+
     // parse the hash of the sharing URL
     const shared_params = parseSharedURL();
 
+    /**
+    * the close dialog handler
+    */
+    const handleClose = () => {
+        setShowShareComment(false);
+    };
+
     // if there was a comment, display it
-    if ( shared_params['comment'] !== '') {
+    if ( shared_params['comment'] !== '' && showShareComment ) {
         return (
             <Card variant="outlined" sx={{maxWidth: '100%'}}>
                 <Typography sx={{ wordBreak: "break-word" }} color={"primary"}>Share comment: { shared_params['comment']}</Typography>
+
+                <IconButton size="small" autoFocus onClick={ handleClose } sx={{ position: 'absolute', right: 8, top: 8 }}>
+                    <CloseOutlinedIcon color={"primary"}/>
+                </IconButton>
             </Card>
         );
     }

--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -24,7 +24,7 @@ export const Share = () => {
                     height: 50,
                     width: 80,
                     padding: '0px',
-                    zIndex: 401,
+                    zIndex: 410,
                     borderRadius: 'sm'
               }}>
                 <Stack

--- a/src/components/sidebar/sidebar.js
+++ b/src/components/sidebar/sidebar.js
@@ -28,7 +28,7 @@ export const Sidebar = () => {
           position: 'absolute',
           top: 0, left: 0,
           height: '100vh',
-          zIndex: 401,
+          zIndex: 410,
           maxWidth: '68px',
           overflow: 'hidden',
           p: 0,

--- a/src/components/sidebar/tray.js
+++ b/src/components/sidebar/tray.js
@@ -17,7 +17,7 @@ export const Tray = ({ active, Contents, title, closeHandler }) => {
         transition: 'transform 250ms',
         height: '100vh',
         width: TRAY_WIDTH,
-        zIndex: 401,
+        zIndex: 410,
         filter: 'drop-shadow(0 0 8px rgba(0, 0, 0, 0.2))',
         overflowX: 'hidden',
         overflowY: 'auto',

--- a/src/components/trays/help-about/helpAboutTray.js
+++ b/src/components/trays/help-about/helpAboutTray.js
@@ -41,7 +41,7 @@ export const HelpAboutTray = () => {
                         </Accordion>
 
                         <Accordion expanded={index === 4} onChange={ (event, expanded) => { setIndex(expanded ? 4 : null); }}>
-                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I capture a screenshot ?</Typography> </AccordionSummary>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I capture a screenshot?</Typography> </AccordionSummary>
                             <AccordionDetails>
                                 <AccordionGroup>
                                     <Accordion  expanded={ subIndex === 0 } onChange={ (event, expanded) => { setSubIndex(expanded ? 0 : null); }}>

--- a/src/components/trays/help-about/helpAboutTray.js
+++ b/src/components/trays/help-about/helpAboutTray.js
@@ -15,15 +15,15 @@ export const HelpAboutTray = () => {
     return (
         <Fragment>
             <Stack gap={ 3 }>
-                <AccordionGroup sx={{size: "sm", variant: "soft"}}>
+                <AccordionGroup sx={{ size: "sm", variant: "soft" }}>
                 <Typography level="title-lg"> About </Typography>
                     <Stack spacing={1}>
-                        <Accordion expanded={index === 0} onChange={(event, expanded) => { setIndex(expanded ? 0 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg"> Application version </Typography> </AccordionSummary>
-                            <AccordionDetails> Version: {process.env.REACT_APP_VERSION}</AccordionDetails>
+                        <Accordion expanded={index === 0} onChange={ (event, expanded) => { setIndex(expanded ? 0 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}> Application version </Typography> </AccordionSummary>
+                            <AccordionDetails> Version: { process.env.REACT_APP_VERSION }</AccordionDetails>
                         </Accordion>
-                        <Accordion expanded={index === 1} onChange={(event, expanded) => { setIndex(expanded ? 1 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg"> Application description </Typography> </AccordionSummary>
+                        <Accordion expanded={index === 1} onChange={ (event, expanded) => { setIndex(expanded ? 1 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}> Application description </Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
                     </Stack>
@@ -31,21 +31,21 @@ export const HelpAboutTray = () => {
             </Stack>
 
             <Stack>
-                <AccordionGroup sx={{size: "sm", variant: "soft"}}>
+                <AccordionGroup sx={{ size: "sm", variant: "soft" }}>
                     <Typography level="h4">FAQs</Typography>
                     <Stack spacing={1}>
 
-                        <Accordion expanded={index === 3} onChange={(event, expanded) => { setIndex(expanded ? 3 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">What FAQs should we put in here?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 3} onChange={ (event, expanded) => { setIndex(expanded ? 3 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>What FAQs should we put in here?</Typography> </AccordionSummary>
                             <AccordionDetails> What sort of things should we be putting in the FAQs? Below are some examples... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 4} onChange={(event, expanded) => { setIndex(expanded ? 4 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I capture a screenshot ?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 4} onChange={ (event, expanded) => { setIndex(expanded ? 4 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I capture a screenshot ?</Typography> </AccordionSummary>
                             <AccordionDetails>
                                 <AccordionGroup>
-                                    <Accordion  expanded={subIndex === 0} onChange={(event, expanded) => { setSubIndex(expanded ? 0 : null); }}>
-                                        <AccordionSummary>Edge</AccordionSummary>
+                                    <Accordion  expanded={ subIndex === 0 } onChange={ (event, expanded) => { setSubIndex(expanded ? 0 : null); }}>
+                                        <AccordionSummary sx={{fontStyle: 'italic'}}>Edge</AccordionSummary>
                                             <AccordionDetails>
                                                     <ul>
                                                         <li>Right click the browser surface.</li>
@@ -56,8 +56,8 @@ export const HelpAboutTray = () => {
                                             </AccordionDetails>
                                     </Accordion>
 
-                                    <Accordion  expanded={subIndex === 1} onChange={(event, expanded) => { setSubIndex(expanded ? 1 : null); }}>
-                                        <AccordionSummary>Firefox</AccordionSummary>
+                                    <Accordion  expanded={ subIndex === 1 } onChange={ (event, expanded) => { setSubIndex(expanded ? 1 : null); }}>
+                                        <AccordionSummary sx={{ fontStyle: 'italic' }}>Firefox</AccordionSummary>
                                             <AccordionDetails>
                                                 <ul>
                                                     <li>Right click the browser surface</li>
@@ -68,8 +68,8 @@ export const HelpAboutTray = () => {
                                             </AccordionDetails>
                                     </Accordion>
 
-                                    <Accordion  expanded={subIndex === 2} onChange={(event, expanded) => { setSubIndex(expanded ? 2 : null); }}>
-                                        <AccordionSummary>Chrome</AccordionSummary>
+                                    <Accordion  expanded={ subIndex === 2 } onChange={ (event, expanded) => { setSubIndex(expanded ? 2 : null); }}>
+                                        <AccordionSummary sx={{ fontStyle: 'italic' }}>Chrome</AccordionSummary>
                                             <AccordionDetails>
                                                 <ul>
                                                     <li>Install and activate the Chrome Full Page Screen Capture browser extension.</li>
@@ -80,8 +80,8 @@ export const HelpAboutTray = () => {
                                             </AccordionDetails>
                                     </Accordion>
 
-                                    <Accordion  expanded={subIndex === 3} onChange={(event, expanded) => { setSubIndex(expanded ? 3 : null); }}>
-                                        <AccordionSummary>Safari</AccordionSummary>
+                                    <Accordion  expanded={ subIndex === 3 } onChange={ (event, expanded) => { setSubIndex(expanded ? 3 : null); }}>
+                                        <AccordionSummary sx={{ fontStyle: 'italic' }}>Safari</AccordionSummary>
                                             <AccordionDetails>
                                                 <ul>
                                                     <li>Install and activate Awesome Screenshot</li>
@@ -97,48 +97,48 @@ export const HelpAboutTray = () => {
                             </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 5} onChange={(event, expanded) => { setIndex(expanded ? 5 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">What are some features of this application?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 5} onChange={ (event, expanded) => { setIndex(expanded ? 5 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>What are some features of this application?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 6} onChange={(event, expanded) => { setIndex(expanded ? 6 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I add/remove Layers on the map?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 6} onChange={ (event, expanded) => { setIndex(expanded ? 6 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I add/remove Layers on the map?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 7} onChange={(event, expanded) => { setIndex(expanded ? 7 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I move through synoptic cycles?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 7} onChange={ (event, expanded) => { setIndex(expanded ? 7 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I move through synoptic cycles?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 8} onChange={(event, expanded) => { setIndex(expanded ? 8 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">What do the icons on the left mean?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 8} onChange={ (event, expanded) => { setIndex(expanded ? 8 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>What do the icons on the left mean?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 9} onChange={(event, expanded) => { setIndex(expanded ? 9 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">What are some user settings?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 9} onChange={ (event, expanded) => { setIndex(expanded ? 9 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>What are some user settings?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 10} onChange={(event, expanded) => { setIndex(expanded ? 10 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I change the base map?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 10} onChange={ (event, expanded) => { setIndex(expanded ? 10 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I change the base map?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 11} onChange={(event, expanded) => { setIndex(expanded ? 11 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I view observation data?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 11} onChange={ (event, expanded) => { setIndex(expanded ? 11 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I view observation data?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 12} onChange={(event, expanded) => { setIndex(expanded ? 12 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I show/hide layers?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 12} onChange={ (event, expanded) => { setIndex(expanded ? 12 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I show/hide layers?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 
-                        <Accordion expanded={index === 13} onChange={(event, expanded) => { setIndex(expanded ? 13 : null); }}>
-                            <AccordionSummary> <Typography level="title-lg">How do I reorder layers on the map?</Typography> </AccordionSummary>
+                        <Accordion expanded={index === 13} onChange={ (event, expanded) => { setIndex(expanded ? 13 : null); }}>
+                            <AccordionSummary> <Typography level="title-md" sx={{ fontStyle: 'italic', fontWeight: 'bold' }}>How do I reorder layers on the map?</Typography> </AccordionSummary>
                             <AccordionDetails> Add some content here... </AccordionDetails>
                         </Accordion>
 

--- a/src/components/trays/settings/chart-yaxis.js
+++ b/src/components/trays/settings/chart-yaxis.js
@@ -46,6 +46,7 @@ export const ObsChartYAxis = () => {
                         marks={ marks }
                         min={-20}
                         max={20}
+                        disableSwap
                         sx={{
                             "--Slider-thumbWidth": "8px",
                             "--Slider-valueLabelArrowSize": "-1px",

--- a/src/components/trays/settings/chart-yaxis.js
+++ b/src/components/trays/settings/chart-yaxis.js
@@ -1,0 +1,76 @@
+import React, { Fragment } from 'react';
+import { IconButton, Stack, Typography, Slider, Box } from '@mui/joy';
+import { useSettings } from '@context';
+import LineAxisRoundedIcon from '@mui/icons-material/LineAxisRounded';
+
+/**
+ * renders the observation chart Y-axis slider
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export const ObsChartYAxis = () => {
+    // get the settings for the obs chart Y-axis min/max values
+    const { obsChartY, setObsChartY } = useSettings();
+
+    // capture the slider values
+    const handleChange = (event, newValue) => {
+        // save the value to state
+        setObsChartY(newValue);
+    };
+
+    // mark the line
+    const marks = [ { value: -20 }, { value: -10 }, { value: 0 }, { value: 10 }, { value: 20 } ];
+
+    // render the control
+    return (
+        <Stack
+            direction="row"
+            justifyContent="flex-start"
+            alignItems="flex-start"
+            gap={2}
+        >
+            <YAxisSlider/>
+
+            <div>
+                <Typography level="title-md">Observation chart Y-axis [{ obsChartY.map(x => x).join(' -> ') }]</Typography>
+
+                <Box width={400} >
+                    <Slider
+                        getAriaLabel={() => 'Y-Axis'}
+                        value={ obsChartY }
+                        defaultValue={ obsChartY }
+                        onChange={ handleChange }
+                        valueLabelDisplay="auto"
+                        step={ 0.5 }
+                        marks={ marks }
+                        min={-20}
+                        max={20}
+                        sx={{
+                            "--Slider-thumbWidth": "8px",
+                            "--Slider-valueLabelArrowSize": "-1px",
+                            "--Slider-trackSize": "3px",
+                            "--Slider-markSize": "3px"
+                        }}
+                    />
+                </Box>
+            </div>
+        </Stack>
+    );
+};
+
+/**
+ * renders the icon
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export const YAxisSlider = () => {
+    // render the control
+    return (
+        <Fragment>
+            <IconButton id="chart-y-axis-slider" size="lg" variant="outlined" >
+                <LineAxisRoundedIcon />
+            </IconButton>
+        </Fragment>);
+};

--- a/src/components/trays/settings/index.js
+++ b/src/components/trays/settings/index.js
@@ -4,14 +4,16 @@ import { Tune as SettingsIcon } from '@mui/icons-material';
 
 import { DarkModeToggle } from './dark-mode';
 import { BaseMaps } from './basemap';
+import { ObsChartYAxis } from './chart-yaxis';
 
 export const icon = <SettingsIcon />;
 
 export const title = 'Settings';
 
 export const trayContents = () => (
-  <Stack gap={ 2 } p={ 2 }>
+  <Stack gap={ 1 } p={ 1 }>
     <DarkModeToggle />
     <BaseMaps />
+    <ObsChartYAxis />
   </Stack>
 );

--- a/src/context/map-context.js
+++ b/src/context/map-context.js
@@ -83,7 +83,8 @@ export const LayersProvider = ({ children }) => {
 
   const getAllLayersInvisible = () => {
     const currentLayers = [...defaultModelLayers];
-    const alteredLayers = currentLayers
+
+    return currentLayers
       .map((layer) => {
         const opacity = layer.state.opacity;
         return {
@@ -91,8 +92,6 @@ export const LayersProvider = ({ children }) => {
           state: {visible: false, opacity: opacity}
         };
       });
-  
-    return alteredLayers;
   };
 
   const swapLayers = (i, j) => {
@@ -146,8 +145,7 @@ export const LayersProvider = ({ children }) => {
         toggleHurricaneLayerVisibility,
         toggleLayerVisibility,
         getAllLayersInvisible,
-        selectedObservations,
-        setSelectedObservations,
+        selectedObservations, setSelectedObservations,
         swapLayers,
         removeLayer,
         layerTypes,

--- a/src/context/map-context.js
+++ b/src/context/map-context.js
@@ -132,6 +132,8 @@ export const LayersProvider = ({ children }) => {
 
   const [baseMap, setBaseMap] = React.useState();
 
+  // used to track the view state of the share comment
+  const [ showShareComment, setShowShareComment ] = useState(true);
 
   return (
     <LayersContext.Provider
@@ -146,6 +148,7 @@ export const LayersProvider = ({ children }) => {
         toggleLayerVisibility,
         getAllLayersInvisible,
         selectedObservations, setSelectedObservations,
+        showShareComment, setShowShareComment,
         swapLayers,
         removeLayer,
         layerTypes,

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -3,7 +3,9 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useState
 } from "react";
+
 import PropTypes from "prop-types";
 import { useColorScheme } from '@mui/joy/styles';
 import {
@@ -25,13 +27,18 @@ export const SettingsProvider = ({ children }) => {
     setMode(darkMode ? 'light' : 'dark');
   }, [mode]);
 
+  // used to capture the selected observation chart min/max Y-axis
+  const [obsChartY, setObsChartY] = useState([-2, 2]);
+
   return (
     <SettingsContext.Provider value={{
       booleanValue,
+
       darkMode: {
         enabled: darkMode,
         toggle: toggleDarkMode,
       },
+      obsChartY, setObsChartY,
     }}>
       { children }
     </SettingsContext.Provider>

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -83,14 +83,17 @@ export const parseSharedURL = () => {
  * @param setSelectedObservations
  */
 export const addSharedObservations = (map, obs, setSelectedObservations )=> {
-    // put a target icon on the map and observation data in state
-    obs.forEach(r => {
-        // put the target icons on the map
-        markClicked(map, {'latlng': {'lat': r.lat, 'lng': r.lng}}, r.id);
+    // if there are observations, put them on the map
+    if(obs) {
+        // put a target icon on the map and observation data in state
+        obs.forEach(r => {
+            // put the target icons on the map
+            markClicked(map, {'latlng': {'lat': r.lat, 'lng': r.lng}}, r.id);
 
-        // add the selected observation data into state
-        setSelectedObservations(previous => [...previous, r]);
-    });
+            // add the selected observation data into state
+            setSelectedObservations(previous => [...previous, r]);
+        });
+    }
 };
 
 // add any new basemaps here

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -30,7 +30,6 @@ export const markClicked = (map, event, id) => {
 
 
 export const markUnclicked = (map, id) => {
-
   map.eachLayer((layer) => {
     if (layer.options && layer.options.pane === "markerPane") {
       if (layer._id === id) {
@@ -85,6 +84,9 @@ export const parseSharedURL = () => {
 export const addSharedObservations = (map, obs, setSelectedObservations )=> {
     // if there are observations, put them on the map
     if(obs) {
+        // clear out the current selected observation dialogs
+        setSelectedObservations([]);
+
         // put a target icon on the map and observation data in state
         obs.forEach(r => {
             // put the target icons on the map


### PR DESCRIPTION
This branch/PR adds:

- cascading observation dialogs when more than 1 observation points are selected
- a new settings control to adjust the Y-axis range on the observation chart.
- adding a close button for the shared link comment
- adjusting z-orders so the observation dialog is beneath the tray.

if this PR is satisfactory, please merge and remove the branch.