### PR TITLE
bugfix: map refetching data on window/tab focus

### DIFF
--- a/src/components/map/default-layers.js
+++ b/src/components/map/default-layers.js
@@ -134,7 +134,12 @@ export const DefaultLayers = () => {
         }
         return(data);
     };
-    useQuery( {queryKey: ['apsviz-default-data', data_url], queryFn: getDefaultLayers, enable: !!data_url});
+    useQuery({
+        queryKey: ['apsviz-default-data', data_url],
+        queryFn: getDefaultLayers,
+        enable: !!data_url,
+        refetchOnWindowFocus: false,
+    });
 
     // maybe should convert this one to use useQuery - not sure how to do that yet
     useEffect(() => {

--- a/src/components/trays/model-selection/synopticTab.js
+++ b/src/components/trays/model-selection/synopticTab.js
@@ -93,7 +93,9 @@ export const SynopticTabForm = () => {
 
             // return something
             return true;
-        }
+        },
+
+        refetchOnWindowFocus: false
     });
 
     /**

--- a/src/components/trays/model-selection/tropicalTab.js
+++ b/src/components/trays/model-selection/tropicalTab.js
@@ -90,7 +90,10 @@ export const TropicalTabForm = () => {
 
             // return something
             return true;
-        }
+        },
+
+        refetchOnWindowFocus: false
+
     });
 
     /**


### PR DESCRIPTION
this PR prevents the default and undesired behavior of refetching on window focus by adding a configuration variable  &mdash; `refetchOnWindowFocus: false` &mdash; to our three usages of `useQuery`. the issue this PR addresses, #125, only mentions the map refetching, but the model selection forms were also refetching, so those instances were also addressed here.