### PR TITLE
#185 upgraded version of geostyler-sld-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15380,12 +15380,13 @@
       "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "dayjs": "^1.11.11",
         "dotenv": "^16.4.5",
         "geostyler": "^15.0.0",
-        "geostyler-sld-parser": "^6.1.1",
+        "geostyler-sld-parser": "^6.1.2",
         "html-to-image": "^1.11.11",
         "leaflet": "^1.9.4",
         "mapbox-gl": "^3.1.2",
@@ -10784,9 +10784,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",
@@ -11383,11 +11383,11 @@
       }
     },
     "node_modules/geostyler-sld-parser": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-6.1.1.tgz",
-      "integrity": "sha512-XzU5gcXUrWW2JE1V+Sq0HGw3euHRjoOBwgi60BSJDpJ88MFUpa6Qm1AOl/9Qg5V+ztumAwDJQsZSHKj25QP/jQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-6.1.2.tgz",
+      "integrity": "sha512-85Egj8xCEBLPGil+Q/scc0P2HYiB53MgLAQ6Z3Uwxwg2vRUXFSJUT6rYvdb9fCsYyTT8MqSriT+AsjpD1d8huw==",
       "dependencies": {
-        "fast-xml-parser": "^4.2.2",
+        "fast-xml-parser": "^4.4.1",
         "geostyler-style": "^9.1.0",
         "lodash": "^4.17.21"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dayjs": "^1.11.11",
     "dotenv": "^16.4.5",
     "geostyler": "^15.0.0",
-    "geostyler-sld-parser": "^6.1.1",
+    "geostyler-sld-parser": "^6.1.2",
     "html-to-image": "^1.11.11",
     "leaflet": "^1.9.4",
     "mapbox-gl": "^3.1.2",


### PR DESCRIPTION
geostyler-sld-parser has issued a new release (6.1.2) so the UI has been updated to use it.
this addresses the high severity vulnerability.