### PR TITLE
Merge functionality to get layer type icons.

### DIFF
--- a/src/components/legend/legend.js
+++ b/src/components/legend/legend.js
@@ -15,18 +15,17 @@ export const MapLegend = () => {
 
     const [legendUrl, setLegendUrl] = useState("");
     const [legendVisibilty, setLegendVisibilty] = useState("hidden");
+    const [layerIcon, setLayerIcon] = useState("");
 
     const sldParser = new SldStyleParser();
 
     const {
         defaultModelLayers,
-        layerTypes,
+        getLayerIcon
     } = useLayers();
     const {
         mapStyle,
     } = useSettings();
-
-    let LegendIcon = layerTypes['maxele63'].icon;
 
     useEffect(() => {
         const legendLayer = defaultModelLayers.find(layer => layer.state.visible && layer.properties.product_type !== 'obs');
@@ -34,7 +33,7 @@ export const MapLegend = () => {
             setLegendVisibilty("hidden");
         }
         else {
-            LegendIcon = layerTypes[legendLayer.properties.product_type].icon;
+            setLayerIcon(getLayerIcon(legendLayer.properties.product_type));
 
             // now build appropriate url for retrieving the legend graphic
             const workspace = legendLayer.layers.split(':')[0];
@@ -141,7 +140,7 @@ export const MapLegend = () => {
                             alignItems="center"
                         >
                             <Avatar variant="outlined" id="draggable-card"  sx={{ m: -1, p: 0, height: 40, cursor: 'move' }}>
-                                <LegendIcon size="lg" color="primary" />
+                                { layerIcon }
                             </Avatar>
 
                             <Box

--- a/src/components/trays/compare-layers/CompareLayersTray.js
+++ b/src/components/trays/compare-layers/CompareLayersTray.js
@@ -41,7 +41,7 @@ export const CompareLayersTray = () => {
     const {
         map,
         defaultModelLayers,
-        layerTypes,
+        getLayerIcon,
         setSideBySideLayers,
         removeSideBySideLayers
     } = useLayers();
@@ -155,20 +155,6 @@ export const CompareLayersTray = () => {
         setRightPaneType(origLeftPaneType);
         setRightPaneID(origLeftPaneID);
         setRightLayerProps(origLeftLayerProps);
-    };
-
-    /**
-     * get the layer icon
-     *
-     * @param productType
-     * @returns {JSX.Element}
-     */
-    const getLayerIcon = ( productType )=> {
-        // grab the icon
-        const Icon = layerTypes[productType].icon;
-
-        // return the icon
-        return <Icon/>;
     };
 
     /**

--- a/src/components/trays/layers/layer-card.js
+++ b/src/components/trays/layers/layer-card.js
@@ -23,13 +23,12 @@ import { DeleteLayerButton } from './delete-layer-button';
 
 export const LayerCard = ({ index, layer }) => {
   const {
-    layerTypes,
+    getLayerIcon,
     swapLayers,
     toggleLayerVisibility,
   } = useLayers();
   const expanded = useToggleState(false);
   const isVisible = layer.state.visible;
-  const LayerIcon = layerTypes[layer.properties.product_type].icon;
 
   return (
     <Accordion
@@ -65,7 +64,7 @@ export const LayerCard = ({ index, layer }) => {
             transition: 'filter 250ms',
           }}>
             <Avatar variant="outlined">
-              <LayerIcon size="lg" color="primary" />
+              { getLayerIcon(layer.properties.product_type) }
             </Avatar>
             <Typography level="title-sm" sx={{ flex: 1 }}>
               {layer.properties.product_name}

--- a/src/context/map-context.js
+++ b/src/context/map-context.js
@@ -52,6 +52,20 @@ export const LayersProvider = ({ children }) => {
   const [sideBySideLayers, setSideBySideLayers] = useState(null);
 
   /**
+   * get the layer icon
+   *
+   * @param productType
+   * @returns {JSX.Element}
+   */
+  const getLayerIcon = ( productType )=> {
+      // grab the icon
+      const Icon = layerTypes[productType].icon;
+
+      // return the icon
+      return <Icon/>;
+  };
+
+  /**
    * removes the side by side compare layers
    *
    */
@@ -283,6 +297,7 @@ export const LayersProvider = ({ children }) => {
         removeAllModelRuns,
         removeObservations,
         layerTypes,
+        getLayerIcon,
         baseMap,
         setBaseMap,
         setLayerOpacity,


### PR DESCRIPTION
Addresses issue #204.

Note: A bug was discovered when assessing this functionality.

there appears to be other opportunities for this functionality that use the mapstyle to determine the icon type.