### PR TITLE
adjusting the z-indexes

### DIFF
--- a/src/components/control-panel/control-panel.js
+++ b/src/components/control-panel/control-panel.js
@@ -338,7 +338,7 @@ export const ControlPanel = () => {
         '&:hover': { filter: 'opacity(1.0)' },
         height: 'auto',
         width: '300px',
-        zIndex: 1001,
+        zIndex: 999,
         borderRadius: 'sm',
       }}
     >

--- a/src/components/legend/legend.js
+++ b/src/components/legend/legend.js
@@ -121,7 +121,7 @@ export const MapLegend = () => {
                         filter: 'opacity(0.9)',
                         '&:hover': { filter: 'opacity(1.0)' },
                         padding: '10px',
-                        zIndex: 1001,
+                        zIndex: 999,
                         borderRadius: 'sm',
                         visibility: legendVisibilty,
 


### PR DESCRIPTION
adjusting the z-indexes of the legend and control panel to be:

- under the tray, 
- under the compare panel selections,
- over the compare slider control,
- a peer to the observation dialogs.