### PR TITLE
forcing the nopp default layers to use the 'coampsforecast' ensemble name

### DIFF
--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -45,7 +45,7 @@ export const getBrandingHandler = () =>  {
     let ret_val = '';
 
     // if this is a nopp branding
-    if(window.location.href.includes('nopp') || true) {
+    if(window.location.href.includes('nopp')) {
         // use local host values
         ret_val = '&project_code=nopp&ensemble_name=coampsforecast';
     }

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -45,9 +45,9 @@ export const getBrandingHandler = () =>  {
     let ret_val = '';
 
     // if this is a nopp branding
-    if(window.location.href.includes('nopp')) {
+    if(window.location.href.includes('nopp') || true) {
         // use local host values
-        ret_val = '&project_code=nopp';
+        ret_val = '&project_code=nopp&ensemble_name=coampsforecast';
     }
 
     // return the query string


### PR DESCRIPTION
this addresses part 2 of issue #288 .

currently only the RENCI dev and prod deployments have the DB SP and UI data web services to test this.