### PR TITLE
Issue 296 field units

### DIFF
--- a/src/components/trays/settings/colormaps/colormap-slider.js
+++ b/src/components/trays/settings/colormaps/colormap-slider.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import SldStyleParser from 'geostyler-sld-parser';
 import { Slider, Box } from '@mui/joy';
 import { useSettings } from '@context';
-import { restoreColorMapType, metersToFeet, feetToMeters, mpsToKnots, knotsToMps, mpsToMph, mphToMps  } from '@utils/map-utils';
+import { restoreColorMapType, feetToMeters, knotsToMps, mphToMps  } from '@utils/map-utils';
 import { getFloatNumberFromLabel, maxSliderValues, sliderSteps, sliderMarkSteps } from './utils';
 
 const MAXELE = 'maxele';
@@ -112,31 +112,7 @@ export const ColormapSlider = ({style}) => {
         const dataRange = [];
         const colormapEntries = style.rules[0].symbolizers[0].colorMap.colorMapEntries;
         for(let i = colormapEntries.length-1; i >= 0; i--) {
-            // check to see if units are set to imperial 
-            if (unitsType.current === "imperial") {
-                // handle speed type range
-                if (style.name.includes(MAXWVEL)) {
-                    if (speedType.current === "knots") {
-                        dataRange.push(mpsToKnots(colormapEntries[i].quantity));
-                    }
-                    else {
-                        dataRange.push(mpsToMph(colormapEntries[i].quantity));
-                    }
-                }
-                else {
-                    dataRange.push(metersToFeet(colormapEntries[i].quantity));
-                }
-                
-            }
-            else {
-                dataRange.push(colormapEntries[i].quantity);
-            }
-        }
-        // if this is an intervals type of colormap, correct last entry in range
-        if (style.rules[0].symbolizers[0].colorMap.type === "intervals") {
-            const colorMapEntries = style.rules[0].symbolizers[0].colorMap.colorMapEntries;
-            //dataRange[0] = parseFloat(colorMapEntries[colorMapEntries.length-1].label.match(/[+-]?\d+(\.\d+)?/g)).toFixed(2);
-            dataRange[0] = getFloatNumberFromLabel(colorMapEntries[colorMapEntries.length-1].label, 2);
+            dataRange.push(getFloatNumberFromLabel(colormapEntries[i].label, 2));
         }
     
         return(dataRange.reverse());

--- a/src/components/trays/settings/colormaps/colormap-slider.js
+++ b/src/components/trays/settings/colormaps/colormap-slider.js
@@ -61,7 +61,7 @@ export const ColormapSlider = ({style}) => {
         setMinSliderValue(0);
 
         const colormapEntries = style.rules[0].symbolizers[0].colorMap.colorMapEntries;
-        setValue([getFloatNumberFromLabel(colormapEntries[colormapEntries.length-1].label, 0),
+        setValue([parseFloat(colormapEntries[colormapEntries.length-1].label.match(/[+-]?\d+(\.\d+)?/g)),
                   parseFloat(colormapEntries[0].quantity)]);
     };
 

--- a/src/components/trays/settings/colormaps/data-range.js
+++ b/src/components/trays/settings/colormaps/data-range.js
@@ -15,6 +15,8 @@ export const DataRangeEdit = () => {
 
     const {
         mapStyle,
+        unitsType,
+        speedType,
     } = useSettings();
 
     return (
@@ -36,21 +38,35 @@ export const DataRangeEdit = () => {
                             style={mapStyle.maxele.current}
                         />
                     </Box>
-                    <Typography startDecorator={<MaxElevationIcon />} mb={2} level="title-md">Maximum Water Level</Typography>
+                    <Typography 
+                        startDecorator={<MaxElevationIcon />} 
+                        mb={2} 
+                        level="title-md">
+                            Maximum Water Level {unitsType.current==="metric"? "(meters)" : "(feet)"}
+                    </Typography>
                 
                     <Box width={300} >
                         <ColormapSlider
                             style={mapStyle.maxwvel.current}
                         />
                     </Box>
-                    <Typography startDecorator={<MaxWindVelocityIcon />}  mb={2} level="title-md">Maximum Wind Speed</Typography>
+                    <Typography
+                        startDecorator={<MaxWindVelocityIcon />}
+                        mb={2}
+                        level="title-md">
+                            Maximum Wind Speed ({speedType.current})
+                    </Typography>
                     
                     <Box width={300} >
                         <ColormapSlider
                             style={mapStyle.swan.current}
                         />
                     </Box>
-                    <Typography startDecorator={<SwanIcon />} level="title-md">Maximum Significant Wave Height</Typography>
+                    <Typography 
+                        startDecorator={<SwanIcon />}
+                        level="title-md">
+                            Maximum Significant Wave Height {unitsType.current==="metric"? "(meters)" : "(feet)"}
+                    </Typography>
                 </Stack>
             </TabPanel>
             <TabPanel value={1}>

--- a/src/components/trays/settings/colormaps/utils.js
+++ b/src/components/trays/settings/colormaps/utils.js
@@ -1,5 +1,17 @@
 export const maxSliderValues = {
-    "maxele": 10,
-    "maxwvel": 100,
-    "swan": 30
+    "maxele": { "metric": 10, "imperial": 30 },
+    "maxwvel": { "metric": 100, "imperial": 200 },
+    "swan":  { "metric": 30, "imperial": 100 }
+};
+
+export const sliderSteps = {
+    "maxele": { "metric": 0.25, "imperial": 1 },
+    "maxwvel": { "metric": 1, "imperial": 5 },
+    "swan": { "metric": 0.5, "imperial": 5 }
+};
+
+export const sliderMarkSteps = {
+    "maxele": { "metric": 1, "imperial": 5 },
+    "maxwvel": { "metric": 10, "imperial": 20 },
+    "swan": { "metric": 5, "imperial": 10 }
 };

--- a/src/components/trays/settings/colormaps/utils.js
+++ b/src/components/trays/settings/colormaps/utils.js
@@ -15,3 +15,14 @@ export const sliderMarkSteps = {
     "maxwvel": { "metric": 10, "imperial": 20 },
     "swan": { "metric": 5, "imperial": 10 }
 };
+
+// find a float number in a colormap entry label and 
+// return with designated decimal places.
+export const getFloatNumberFromLabel = (label, decimalPlaces) => {
+    let num = 0.0;
+    const labelMatch = label.match(/[+-]?\d+(\.\d+)?/g);
+    if (labelMatch)
+        num = parseFloat(labelMatch).toFixed(decimalPlaces);
+
+    return num;
+};

--- a/src/components/trays/settings/index.js
+++ b/src/components/trays/settings/index.js
@@ -5,6 +5,7 @@ import { Tune as SettingsIcon } from '@mui/icons-material';
 import { DarkModeToggle } from './dark-mode';
 import { BaseMaps } from './basemap';
 import { DataRangeEdit } from './colormaps';
+import { Units } from './units';
 
 export const icon = <SettingsIcon />;
 
@@ -20,5 +21,8 @@ export const trayContents = () => (
     <Divider sx={{marginTop: 3}}/>
     <Typography mb={1} level="title-lg">Edit ADCIRC Layer Colormaps</Typography>
     <DataRangeEdit />
+    <Divider/>
+    <Typography level="title-lg">Units of measurement</Typography>
+    <Units/>
   </Stack>
 );

--- a/src/components/trays/settings/index.js
+++ b/src/components/trays/settings/index.js
@@ -19,10 +19,11 @@ export const trayContents = () => (
     <Typography level="title-lg">Select a Basemap</Typography>
     <BaseMaps />
     <Divider sx={{marginTop: 3}}/>
+    <Typography level="title-lg">Units of measurement</Typography>
+    <Units/>
+    <Divider sx={{marginTop: 3}}/>
     <Typography mb={1} level="title-lg">Edit ADCIRC Layer Colormaps</Typography>
     <DataRangeEdit />
     <Divider/>
-    <Typography level="title-lg">Units of measurement</Typography>
-    <Units/>
   </Stack>
 );

--- a/src/components/trays/settings/units.js
+++ b/src/components/trays/settings/units.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { IconButton, Typography, Stack} from '@mui/joy';
+
+/**
+ * component that handles changing the units of measurement (distance/speed/time).
+ *            <Typography>Select Imperial units (Feet, MPH)</Typography>
+ *             <Typography>Distance units (Statue or Nautical)</Typography>
+ *
+ *             <Typography>Select Metric units (Meters, KPH)</Typography>
+ *
+ *             <Typography>Time units (UTC or local)</Typography>
+ *
+ *             <Typography>units</Typography>
+ * @returns React.ReactElement
+ * @constructor
+ */
+export const Units = () => {
+
+    return (
+        <Stack
+            direction="row"
+            justifyContent="flex-start"
+            alignItems="flex-start"
+            gap={2}
+        >
+            <Toggler/>
+            <div>
+                <Typography level="title-md">
+                    Select units type
+                </Typography>
+                <Typography level="body-md" variant="soft" color="primary">
+                    Imperial
+                </Typography>
+            </div>
+        </Stack>
+    );
+};
+
+export const Toggler = () => {
+    return (
+        <IconButton
+            id="boolean-value-toggler"
+            size="lg"
+            // onClick={ unitsType.toggle }
+            variant="outlined"
+        >
+            {
+                <Typography>Imperial</Typography>
+            }
+        </IconButton>
+    );
+};

--- a/src/components/trays/settings/units.js
+++ b/src/components/trays/settings/units.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import { IconButton, Typography, Stack} from '@mui/joy';
+import React, { useState } from 'react';
+import { FormControl, RadioGroup, Radio, Sheet, Typography } from '@mui/joy';
+import { useSettings } from '@context';
+
 
 /**
- * component that handles changing the units of measurement (distance/speed/time).
+ * component that handles changing the units of measurement (distance/speed).
  *            <Typography>Select Imperial units (Feet, MPH)</Typography>
  *             <Typography>Distance units (Statue or Nautical)</Typography>
  *
- *             <Typography>Select Metric units (Meters, KPH)</Typography>
- *
- *             <Typography>Time units (UTC or local)</Typography>
+ *             <Typography>Select Metric units (Meters, MPS)</Typography>
  *
  *             <Typography>units</Typography>
  * @returns React.ReactElement
@@ -16,37 +16,65 @@ import { IconButton, Typography, Stack} from '@mui/joy';
  */
 export const Units = () => {
 
-    return (
-        <Stack
-            direction="row"
-            justifyContent="flex-start"
-            alignItems="flex-start"
-            gap={2}
-        >
-            <Toggler/>
-            <div>
-                <Typography level="title-md">
-                    Select units type
-                </Typography>
-                <Typography level="body-md" variant="soft" color="primary">
-                    Imperial
-                </Typography>
-            </div>
-        </Stack>
-    );
-};
+    const {
+        unitsType,
+        speedType,
+    } = useSettings();
 
-export const Toggler = () => {
+    const [unit, setUnit] = useState(unitsType.current);
+    const [speed, setSpeed] = useState(speedType.current);
+
+    const default_speed = {
+        metric: "mps",
+        imperial: "mph",
+    };
+
+    const handleUnitChange = (event) => {
+        console.log(event.target.value);
+        setUnit(event.target.value);
+        unitsType.set(event.target.value);
+        // if units type is set to metric - reset speed type to meters/sec
+        if (event.target.value === "metric") {
+            setSpeed(default_speed.metric);
+            speedType.set(default_speed.metric);
+        }
+        else {
+            setSpeed(default_speed.imperial);
+            speedType.set(default_speed.imperial);
+        }
+    };
+
+    const handleSpeedType = (event) => {
+        console.log(event.target.value);
+        setSpeed(event.target.value);
+        speedType.set(event.target.value);
+    };
+
     return (
-        <IconButton
-            id="boolean-value-toggler"
-            size="lg"
-            // onClick={ unitsType.toggle }
-            variant="outlined"
+        <FormControl>
+        <RadioGroup
+            name="controlled-units-group"
+            value={unit}
+            onChange={handleUnitChange}
         >
-            {
-                <Typography>Imperial</Typography>
-            }
-        </IconButton>
+          <Radio value="metric" label="Metric" size="md" />
+          <Radio value="imperial" label="Imperial" size="md" />
+          {unitsType.current && unitsType.current === "imperial" &&
+            <FormControl>
+            <Sheet variant="outlined" sx={{ marginTop: 2, boxShadow: 'sm', borderRadius: 'sm', p: 1 }}>
+            <Typography level="body-md">Speed units selection:</Typography>
+            <RadioGroup
+                name="controlled-speed-group"
+                value={speed}
+                onChange={handleSpeedType}
+                orientation="horizontal"
+            >
+                <Radio value="mph" label="mph" size="md" />
+                <Radio value="knots" label="knots" size="md" />
+            </RadioGroup>
+            </Sheet>
+            </FormControl>}
+        </RadioGroup>
+      </FormControl>
     );
 };

--- a/src/components/trays/settings/units.js
+++ b/src/components/trays/settings/units.js
@@ -48,7 +48,6 @@ export const Units = () => {
 
     const handleUnitChange = (event) => {
         const unitType = event.target.value;
-        console.log(unitType);
         setUnit(unitType);
         unitsType.set(unitType);
         // if units type is set to metric - reset speed type to meters/sec
@@ -65,7 +64,6 @@ export const Units = () => {
 
     const handleSpeedType = (event) => {
         const stype = event.target.value;
-        console.log(stype);
         setSpeed(stype);
         speedType.set(stype);
         if (stype === "mph") {

--- a/src/components/trays/settings/units.js
+++ b/src/components/trays/settings/units.js
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { FormControl, RadioGroup, Radio, Sheet, Typography } from '@mui/joy';
 import { useSettings } from '@context';
+import { maxeleStyle, maxeleImperialStyle,
+         maxwvelStyle, maxwvelImperialMPHStyle, maxwvelImperialKnotsStyle,
+         swanStyle, swanImperialStyle } from '@utils';
 
 
 /**
@@ -17,6 +20,7 @@ import { useSettings } from '@context';
 export const Units = () => {
 
     const {
+        mapStyle,
         unitsType,
         speedType,
     } = useSettings();
@@ -29,12 +33,26 @@ export const Units = () => {
         imperial: "mph",
     };
 
+    const setLayerStyles = (unitType) => {
+        if (unitType === "metric") {
+            mapStyle.maxele.set(maxeleStyle);
+            mapStyle.swan.set(swanStyle);
+            mapStyle.maxwvel.set(maxwvelStyle);
+        }
+        else {
+            mapStyle.maxele.set(maxeleImperialStyle);
+            mapStyle.swan.set(swanImperialStyle);
+            mapStyle.maxwvel.set(maxwvelImperialMPHStyle);
+        }
+    };
+
     const handleUnitChange = (event) => {
-        console.log(event.target.value);
-        setUnit(event.target.value);
-        unitsType.set(event.target.value);
+        const unitType = event.target.value;
+        console.log(unitType);
+        setUnit(unitType);
+        unitsType.set(unitType);
         // if units type is set to metric - reset speed type to meters/sec
-        if (event.target.value === "metric") {
+        if (unitType === "metric") {
             setSpeed(default_speed.metric);
             speedType.set(default_speed.metric);
         }
@@ -42,12 +60,20 @@ export const Units = () => {
             setSpeed(default_speed.imperial);
             speedType.set(default_speed.imperial);
         }
+        setLayerStyles(unitType);
     };
 
     const handleSpeedType = (event) => {
-        console.log(event.target.value);
-        setSpeed(event.target.value);
-        speedType.set(event.target.value);
+        const stype = event.target.value;
+        console.log(stype);
+        setSpeed(stype);
+        speedType.set(stype);
+        if (stype === "mph") {
+            mapStyle.maxwvel.set(maxwvelImperialMPHStyle);
+        }
+        else {
+            mapStyle.maxwvel.set(maxwvelImperialKnotsStyle);
+        }
     };
 
     return (

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -17,6 +17,18 @@ import { maxeleStyle, maxwvelStyle, swanStyle } from '@utils';
 export const SettingsContext = createContext({});
 export const useSettings = () => useContext(SettingsContext);
 
+export const metersToFeet = (m) => {
+  return m * 3.28084;
+};
+
+export const mpsToMph = (s) => {
+  return s * 2.236936;
+};
+
+export const mpsToKnots = (s) => {
+  return s *1.943844;
+};
+
 export const SettingsProvider = ({ children }) => {
   const { mode, setMode } = useColorScheme();
   const booleanValue = useToggleState();
@@ -37,6 +49,13 @@ export const SettingsProvider = ({ children }) => {
   const [storedMaxwvelOpacity, setStoredMaxwvelOpacity] = useLocalStorage('maxwvel_opacity',1.0);
   const [storedSwanOpacity, setStoredSwanOpacity] = useLocalStorage('swan_opacity',1.0);
 
+  // save the units type specified by user - imperial or metric (default)
+  const [storedUnitsType, setStoredUnitsType] = useLocalStorage('unitsType','metric');
+  // if units type is imperial, need to save wind speed unit - mph or knots
+  // default for metric is meters/second (mps)
+  const [storedSpeedType, setStoredSpeedType] = useLocalStorage('speedType','mps');
+
+
   return (
     <SettingsContext.Provider value={{
       booleanValue,
@@ -45,6 +64,18 @@ export const SettingsProvider = ({ children }) => {
         enabled: darkMode,
         toggle: toggleDarkMode,
       },
+
+      unitsType: {
+        current: storedUnitsType,
+        set: setStoredUnitsType,
+      },
+      speedType: {
+        current: storedSpeedType,
+        set: setStoredSpeedType,
+      },
+      metersToFeet,
+      mpsToMph,
+      mpsToKnots,
 
       mapStyle: {
         maxele: {

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -17,18 +17,6 @@ import { maxeleStyle, maxwvelStyle, swanStyle } from '@utils';
 export const SettingsContext = createContext({});
 export const useSettings = () => useContext(SettingsContext);
 
-export const metersToFeet = (m) => {
-  return m * 3.28084;
-};
-
-export const mpsToMph = (s) => {
-  return s * 2.236936;
-};
-
-export const mpsToKnots = (s) => {
-  return s *1.943844;
-};
-
 export const SettingsProvider = ({ children }) => {
   const { mode, setMode } = useColorScheme();
   const booleanValue = useToggleState();
@@ -73,9 +61,6 @@ export const SettingsProvider = ({ children }) => {
         current: storedSpeedType,
         set: setStoredSpeedType,
       },
-      metersToFeet,
-      mpsToMph,
-      mpsToKnots,
 
       mapStyle: {
         maxele: {

--- a/src/utils/default-styles.js
+++ b/src/utils/default-styles.js
@@ -1,3 +1,4 @@
+// Metric based styles
 export const maxeleStyle = '<?xml version="1.0" encoding="UTF-8"?> \
   <sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0"> \
     <sld:NamedLayer> \
@@ -124,6 +125,190 @@ export const swanStyle = '<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayer
               <sld:ColorMapEntry color="#C42502" quantity="18.0" label="18.0 m"/> \
               <sld:ColorMapEntry color="#A31201" quantity="19.0" label="19.0 m"/> \
               <sld:ColorMapEntry color="#7A0402" quantity="20.0" label="20.0 m"/> \
+            </sld:ColorMap> \
+            <sld:ContrastEnhancement/> \
+          </sld:RasterSymbolizer> \
+        </sld:Rule> \
+      </sld:FeatureTypeStyle> \
+    </sld:UserStyle> \
+  </sld:NamedLayer> \
+</sld:StyledLayerDescriptor>';
+
+// Imperial based styles
+export const maxeleImperialStyle = '<?xml version="1.0" encoding="UTF-8"?> \
+  <sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0"> \
+    <sld:NamedLayer> \
+    <sld:Name>maxele_client_style</sld:Name> \
+    <sld:UserStyle> \
+      <sld:Name>maxele_client_style</sld:Name> \
+      <sld:FeatureTypeStyle> \
+        <sld:Name>name</sld:Name> \
+        <sld:Rule> \
+          <sld:RasterSymbolizer> \
+            <sld:ChannelSelection> \
+              <sld:GrayChannel> \
+                <sld:SourceChannelName>1</sld:SourceChannelName> \
+                <sld:ContrastEnhancement> \
+                  <sld:GammaValue>1.0</sld:GammaValue> \
+                </sld:ContrastEnhancement> \
+              </sld:GrayChannel> \
+            </sld:ChannelSelection> \
+            <sld:ColorMap> \
+              <sld:ColorMapEntry color="#313695" quantity="0.00" label="0.00 m"/> \
+              <sld:ColorMapEntry color="#323C98" quantity="0.3048" label="1.0 ft"/> \
+              <sld:ColorMapEntry color="#4E80B9" quantity="0.6096" label="2.0 ft"/> \
+              <sld:ColorMapEntry color="#84BAD8" quantity="0.9144000000000001" label="3.0 ft"/> \
+              <sld:ColorMapEntry color="#C0E3EF" quantity="1.2192" label="4.0 ft"/> \
+              <sld:ColorMapEntry color="#EFF9DB" quantity="1.524" label="5.0 ft"/> \
+              <sld:ColorMapEntry color="#FEECA2" quantity="1.8288000000000002" label="6.0 ft"/> \
+              <sld:ColorMapEntry color="#FDBD6F" quantity="2.1336" label="7.0 ft"/> \
+              <sld:ColorMapEntry color="#F57A49" quantity="2.4384" label="8.0 ft"/> \
+              <sld:ColorMapEntry color="#D93629" quantity="2.7432000000000003" label="9.0 ft"/> \
+              <sld:ColorMapEntry color="#A50026" quantity="3.048" label="10.0 ft"/> \
+            </sld:ColorMap> \
+            <sld:ContrastEnhancement/> \
+          </sld:RasterSymbolizer> \
+        </sld:Rule> \
+      </sld:FeatureTypeStyle> \
+    </sld:UserStyle> \
+  </sld:NamedLayer> \
+</sld:StyledLayerDescriptor>';
+
+export const maxwvelImperialMPHStyle = '<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0"> \
+  <sld:NamedLayer> \
+    <sld:Name>maxwvel_client_style</sld:Name> \
+    <sld:UserStyle> \
+      <sld:Name>maxwvel_client_style</sld:Name> \
+      <sld:FeatureTypeStyle> \
+        <sld:Name>name</sld:Name> \
+        <sld:Rule> \
+          <sld:RasterSymbolizer> \
+            <sld:ChannelSelection> \
+              <sld:GrayChannel> \
+                <sld:SourceChannelName>1</sld:SourceChannelName> \
+                <sld:ContrastEnhancement> \
+                  <sld:GammaValue>1.0</sld:GammaValue> \
+                </sld:ContrastEnhancement> \
+              </sld:GrayChannel> \
+            </sld:ChannelSelection> \
+            <sld:ColorMap> \
+              <sld:ColorMapEntry color="#3E26A9" quantity="0.0" label="0.0 mph"/> \
+              <sld:ColorMapEntry color="#4433CD" quantity="2.2352" label="5.0 mph"/> \
+              <sld:ColorMapEntry color="#4743E8" quantity="4.4704" label="10.0 mph"/> \
+              <sld:ColorMapEntry color="#4755F6" quantity="6.7056" label="15.0 mph"/> \
+              <sld:ColorMapEntry color="#4367FE" quantity="8.9408" label="20.0 mph"/> \
+              <sld:ColorMapEntry color="#337AFD" quantity="11.176" label="25.0 mph"/> \
+              <sld:ColorMapEntry color="#2D8CF4" quantity="13.4112" label="30.0 mph"/> \
+              <sld:ColorMapEntry color="#259CE8" quantity="15.6464" label="35.0 mph"/> \
+              <sld:ColorMapEntry color="#1BAADF" quantity="17.8816" label="40.0 mph"/> \
+              <sld:ColorMapEntry color="#04B6CE" quantity="20.1168" label="45.0 mph"/> \
+              <sld:ColorMapEntry color="#12BEB9" quantity="22.352" label="50.0 mph"/> \
+              <sld:ColorMapEntry color="#2FC5A2" quantity="24.5872" label="55.0 mph"/> \
+              <sld:ColorMapEntry color="#47CB86" quantity="26.8224" label="60.0 mph"/> \
+              <sld:ColorMapEntry color="#71CD64" quantity="29.0576" label="65.0 mph"/> \
+              <sld:ColorMapEntry color="#9FC941" quantity="31.2928" label="70.0 mph"/> \
+              <sld:ColorMapEntry color="#C9C128" quantity="33.528" label="75.0 mph"/> \
+              <sld:ColorMapEntry color="#EBBB30" quantity="35.7632" label="80.0 mph"/> \
+              <sld:ColorMapEntry color="#FFC13A" quantity="37.9984" label="85.0 mph"/> \
+              <sld:ColorMapEntry color="#FBD42E" quantity="40.2336" label="90.0 mph"/> \
+              <sld:ColorMapEntry color="#F5E824" quantity="42.4688" label="95.0 mph"/> \
+              <sld:ColorMapEntry color="#FAFB14" quantity="44.704" label="100.0 mph"/> \
+            </sld:ColorMap> \
+            <sld:ContrastEnhancement/> \
+          </sld:RasterSymbolizer> \
+        </sld:Rule> \
+      </sld:FeatureTypeStyle> \
+    </sld:UserStyle> \
+  </sld:NamedLayer> \
+</sld:StyledLayerDescriptor>';
+
+export const maxwvelImperialKnotsStyle = '<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0"> \
+  <sld:NamedLayer> \
+    <sld:Name>maxwvel_client_style</sld:Name> \
+    <sld:UserStyle> \
+      <sld:Name>maxwvel_client_style</sld:Name> \
+      <sld:FeatureTypeStyle> \
+        <sld:Name>name</sld:Name> \
+        <sld:Rule> \
+          <sld:RasterSymbolizer> \
+            <sld:ChannelSelection> \
+              <sld:GrayChannel> \
+                <sld:SourceChannelName>1</sld:SourceChannelName> \
+                <sld:ContrastEnhancement> \
+                  <sld:GammaValue>1.0</sld:GammaValue> \
+                </sld:ContrastEnhancement> \
+              </sld:GrayChannel> \
+            </sld:ChannelSelection> \
+            <sld:ColorMap> \
+              <sld:ColorMapEntry color="#3E26A9" quantity="0.0" label="0.0 kn"/> \
+              <sld:ColorMapEntry color="#4433CD" quantity="2.57222" label="5.0 kn"/> \
+              <sld:ColorMapEntry color="#4743E8" quantity="5.14444" label="10.0 kn"/> \
+              <sld:ColorMapEntry color="#4755F6" quantity="7.71666" label="15 kn"/> \
+              <sld:ColorMapEntry color="#4367FE" quantity="10.28888" label="20.0 kn"/> \
+              <sld:ColorMapEntry color="#337AFD" quantity="12.8611" label="25.0 kn"/> \
+              <sld:ColorMapEntry color="#2D8CF4" quantity="15.43332" label="30.0 kn"/> \
+              <sld:ColorMapEntry color="#259CE8" quantity="18.00554" label="35.0 kn"/> \
+              <sld:ColorMapEntry color="#1BAADF" quantity="20.57776" label="40.0 kn"/> \
+              <sld:ColorMapEntry color="#04B6CE" quantity="23.14998" label="45.0 kn"/> \
+              <sld:ColorMapEntry color="#12BEB9" quantity="25.7222" label="50.0 kn"/> \
+              <sld:ColorMapEntry color="#2FC5A2" quantity="28.294420000000002" label="55.0 kn"/> \
+              <sld:ColorMapEntry color="#47CB86" quantity="30.86664" label="60.0 kn"/> \
+              <sld:ColorMapEntry color="#71CD64" quantity="33.43886" label="65.0 kn"/> \
+              <sld:ColorMapEntry color="#9FC941" quantity="36.01108" label="70.0 kn"/> \
+              <sld:ColorMapEntry color="#C9C128" quantity="38.5833" label="75.0 kn"/> \
+              <sld:ColorMapEntry color="#EBBB30" quantity="41.15552" label="80.0 kn"/> \
+              <sld:ColorMapEntry color="#FFC13A" quantity="43.727740000000004" label="85.0 kn"/> \
+              <sld:ColorMapEntry color="#FBD42E" quantity="46.29996" label="90.0 kn"/> \
+              <sld:ColorMapEntry color="#F5E824" quantity="48.87218" label="95.0 kn"/> \
+              <sld:ColorMapEntry color="#FAFB14" quantity="51.4444" label="100.0 kn"/> \
+            </sld:ColorMap> \
+            <sld:ContrastEnhancement/> \
+          </sld:RasterSymbolizer> \
+        </sld:Rule> \
+      </sld:FeatureTypeStyle> \
+    </sld:UserStyle> \
+  </sld:NamedLayer> \
+</sld:StyledLayerDescriptor>';
+
+export const swanImperialStyle = '<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0"> \
+  <sld:NamedLayer> \
+    <sld:Name>swan_client_style</sld:Name> \
+    <sld:UserStyle> \
+      <sld:Name>swan_client_style</sld:Name> \
+      <sld:FeatureTypeStyle> \
+        <sld:Name>name</sld:Name> \
+        <sld:Rule> \
+          <sld:RasterSymbolizer> \
+            <sld:ChannelSelection> \
+              <sld:GrayChannel> \
+                <sld:SourceChannelName>1</sld:SourceChannelName> \
+                <sld:ContrastEnhancement> \
+                  <sld:GammaValue>1.0</sld:GammaValue> \
+                </sld:ContrastEnhancement> \
+              </sld:GrayChannel> \
+            </sld:ChannelSelection> \
+            <sld:ColorMap> \
+              <sld:ColorMapEntry color="#30123B" quantity="0.0" label="0.0 ft"/> \
+              <sld:ColorMapEntry color="#3D3790" quantity="0.9144000000000001" label="3.0 ft"/> \
+              <sld:ColorMapEntry color="#455ACD" quantity="1.8288000000000002" label="6.0 ft"/> \
+              <sld:ColorMapEntry color="#467BF3" quantity="2.7432000000000003" label="9.0 ft"/> \
+              <sld:ColorMapEntry color="#3E9BFF" quantity="3.6576000000000004" label="12.0 ft"/> \
+              <sld:ColorMapEntry color="#28BBEC" quantity="4.572" label="15.0 ft"/> \
+              <sld:ColorMapEntry color="#18D7CC" quantity="5.486400000000001" label="18.0 ft"/> \
+              <sld:ColorMapEntry color="#21EBAC" quantity="6.4008" label="21.0 ft"/> \
+              <sld:ColorMapEntry color="#46F884" quantity="7.315200000000001" label="24.0 ft"/> \
+              <sld:ColorMapEntry color="#78FF5A" quantity="8.2296" label="27.0 ft"/> \
+              <sld:ColorMapEntry color="#A3FD3C" quantity="9.144" label="30.0 ft"/> \
+              <sld:ColorMapEntry color="#C4F133" quantity="10.0584" label="33.0 ft"/> \
+              <sld:ColorMapEntry color="#E2DD37" quantity="10.972800000000001" label="36.0 ft"/> \
+              <sld:ColorMapEntry color="#F6C33A" quantity="11.8872" label="39.0 ft"/> \
+              <sld:ColorMapEntry color="#FEA531" quantity="12.8016" label="42.0 ft"/> \
+              <sld:ColorMapEntry color="#FC8021" quantity="13.716000000000001" label="45.0 ft"/> \
+              <sld:ColorMapEntry color="#F05B11" quantity="14.630400000000002" label="48.0 ft"/> \
+              <sld:ColorMapEntry color="#DE3D08" quantity="15.5448" label="51.0 ft"/> \
+              <sld:ColorMapEntry color="#C42502" quantity="16.4592" label="54.0 ft"/> \
+              <sld:ColorMapEntry color="#A31201" quantity="17.3736" label="57.0 ft"/> \
+              <sld:ColorMapEntry color="#7A0402" quantity="18.288" label="60.0 ft"/> \
             </sld:ColorMap> \
             <sld:ContrastEnhancement/> \
           </sld:RasterSymbolizer> \

--- a/src/utils/default-styles.js
+++ b/src/utils/default-styles.js
@@ -56,27 +56,27 @@ export const maxwvelStyle = '<?xml version="1.0" encoding="UTF-8"?><sld:StyledLa
               </sld:GrayChannel> \
             </sld:ChannelSelection> \
             <sld:ColorMap> \
-              <sld:ColorMapEntry color="#3E26A9" quantity="0.0" label="0.0 m/s"/> \
-              <sld:ColorMapEntry color="#4433CD" quantity="3.0" label="3.0 m/s"/> \
-              <sld:ColorMapEntry color="#4743E8" quantity="6.0" label="6.0 m/s"/> \
-              <sld:ColorMapEntry color="#4755F6" quantity="9.0" label="9.0 m/s"/> \
-              <sld:ColorMapEntry color="#4367FE" quantity="12.0" label="12.0 m/s"/> \
-              <sld:ColorMapEntry color="#337AFD" quantity="15.0" label="15.0 m/s"/> \
-              <sld:ColorMapEntry color="#2D8CF4" quantity="18.0" label="18.0 m/s"/> \
-              <sld:ColorMapEntry color="#259CE8" quantity="21.0" label="21.0 m/s"/> \
-              <sld:ColorMapEntry color="#1BAADF" quantity="24.0" label="24.0 m/s"/> \
-              <sld:ColorMapEntry color="#04B6CE" quantity="27.0" label="27.0 m/s"/> \
-              <sld:ColorMapEntry color="#12BEB9" quantity="30.0" label="30.0 m/s"/> \
-              <sld:ColorMapEntry color="#2FC5A2" quantity="33.0" label="33.0 m/s"/> \
-              <sld:ColorMapEntry color="#47CB86" quantity="36.0" label="36.0 m/s"/> \
-              <sld:ColorMapEntry color="#71CD64" quantity="39.0" label="39.0 m/s"/> \
-              <sld:ColorMapEntry color="#9FC941" quantity="42.0" label="42.0 m/s"/> \
-              <sld:ColorMapEntry color="#C9C128" quantity="45.0" label="45.0 m/s"/> \
-              <sld:ColorMapEntry color="#EBBB30" quantity="48.0" label="48.0 m/s"/> \
-              <sld:ColorMapEntry color="#FFC13A" quantity="51.0" label="51.0 m/s"/> \
-              <sld:ColorMapEntry color="#FBD42E" quantity="54.0" label="54.0 m/s"/> \
-              <sld:ColorMapEntry color="#F5E824" quantity="57.0" label="57.0 m/s"/> \
-              <sld:ColorMapEntry color="#FAFB14" quantity="60.0" label="60.0 m/s"/> \
+              <sld:ColorMapEntry color="#3E26A9" quantity="0.0" label="0.0 mps"/> \
+              <sld:ColorMapEntry color="#4433CD" quantity="3.0" label="3.0 mps"/> \
+              <sld:ColorMapEntry color="#4743E8" quantity="6.0" label="6.0 mps"/> \
+              <sld:ColorMapEntry color="#4755F6" quantity="9.0" label="9.0 mps"/> \
+              <sld:ColorMapEntry color="#4367FE" quantity="12.0" label="12.0 mps"/> \
+              <sld:ColorMapEntry color="#337AFD" quantity="15.0" label="15.0 mps"/> \
+              <sld:ColorMapEntry color="#2D8CF4" quantity="18.0" label="18.0 mps"/> \
+              <sld:ColorMapEntry color="#259CE8" quantity="21.0" label="21.0 mps"/> \
+              <sld:ColorMapEntry color="#1BAADF" quantity="24.0" label="24.0 mps"/> \
+              <sld:ColorMapEntry color="#04B6CE" quantity="27.0" label="27.0 mps"/> \
+              <sld:ColorMapEntry color="#12BEB9" quantity="30.0" label="30.0 mps"/> \
+              <sld:ColorMapEntry color="#2FC5A2" quantity="33.0" label="33.0 mps"/> \
+              <sld:ColorMapEntry color="#47CB86" quantity="36.0" label="36.0 mps"/> \
+              <sld:ColorMapEntry color="#71CD64" quantity="39.0" label="39.0 mps"/> \
+              <sld:ColorMapEntry color="#9FC941" quantity="42.0" label="42.0 mps"/> \
+              <sld:ColorMapEntry color="#C9C128" quantity="45.0" label="45.0 mps"/> \
+              <sld:ColorMapEntry color="#EBBB30" quantity="48.0" label="48.0 mps"/> \
+              <sld:ColorMapEntry color="#FFC13A" quantity="51.0" label="51.0 mps"/> \
+              <sld:ColorMapEntry color="#FBD42E" quantity="54.0" label="54.0 mps"/> \
+              <sld:ColorMapEntry color="#F5E824" quantity="57.0" label="57.0 mps"/> \
+              <sld:ColorMapEntry color="#FAFB14" quantity="60.0" label="60.0 mps"/> \
             </sld:ColorMap> \
             <sld:ContrastEnhancement/> \
           </sld:RasterSymbolizer> \

--- a/src/utils/default-styles.js
+++ b/src/utils/default-styles.js
@@ -154,7 +154,7 @@ export const maxeleImperialStyle = '<?xml version="1.0" encoding="UTF-8"?> \
               </sld:GrayChannel> \
             </sld:ChannelSelection> \
             <sld:ColorMap> \
-              <sld:ColorMapEntry color="#313695" quantity="0.00" label="0.00 m"/> \
+              <sld:ColorMapEntry color="#313695" quantity="0.00" label="0.00 ft"/> \
               <sld:ColorMapEntry color="#323C98" quantity="0.3048" label="1.0 ft"/> \
               <sld:ColorMapEntry color="#4E80B9" quantity="0.6096" label="2.0 ft"/> \
               <sld:ColorMapEntry color="#84BAD8" quantity="0.9144000000000001" label="3.0 ft"/> \

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -297,3 +297,102 @@ export const restoreColorMapType = (typeName, style) => {
 
         return updatedStyle;
 };
+
+// helper functions for unit conversions
+export const feetToMeters = (m) => {
+    return m * 0.3048;
+};
+export const metersToFeet = (m) => {
+    return m * 3.28084;
+};
+
+export const mphToMps = (s) => {
+    return s * 0.44704;
+};
+export const mpsToMph = (s) => {
+    return s * 2.2369;
+};
+
+export const knotsToMps = (s) => {
+    return s * 0.514444;
+};
+export const mpsToKnots = (s) => {
+    return s * 1.943844;
+};
+
+// this functiom converts a style to imperial units
+// styles will always be saved locally in metric units
+// however if the user settings specify imperial units,
+// the style must be converted just before it is used
+// in a GetMap or GetLegend request.
+
+// Save this code for now, is case we decide to do it this way
+// instead of switching to a new default style
+/*
+export const convertStyleUnitsToImperial = (layerType, style, speedType) => {
+    console.log(layerType);
+    console.log(style);
+    console.log(speedType);
+    // helper functions
+    const feetToMeters = (m) => {
+        return m * 0.3048;
+    };
+    const mphToMps = (s) => {
+        return s * 0.44704;
+    };
+    const knotsToMps = (s) => {
+        return s * 0.514444;
+    };
+    const metersToFeet = (m) => {
+        return m * 3.28084;
+    };
+    const mpsToMph = (s) => {
+        return s * 2.2369;
+    };
+    const mpsToKnots = (s) => {
+        return s * 1.943844;
+    };
+
+    const colormap = style.rules[0].symbolizers[0].colorMap.colorMapEntries;
+    let newColormap = [];
+    const numClasses = colormap.length;
+    const colorMapType = style.rules[0].symbolizers[0].colorMap.type;
+    // this for getting max value when color map type is interval
+    const maxValue = parseFloat(colormap[numClasses-1].label.match(/[+-]?\d+(\.\d+)?/g)).toFixed(2);
+    let imperialMaxValue = 0.0;
+    let intervalValue = 0;
+    let speedFunc = mphToMps;
+
+    // see if we are handling distance units or speed units
+    if (layerType === "maxwvel63") {
+        // convert speed units
+        if (speedType === "mph") {
+            imperialMaxValue = Math.round(mpsToMph(maxValue));
+        }
+        else {
+            imperialMaxValue = Math.round(mpsToKnots(maxValue));
+            speedFunc = knotsToMps;
+        }
+        intervalValue = Math.trunc(imperialMaxValue/numClasses);
+        let label = 0.0;
+        colormap.forEach((entry) => {
+            newColormap.push({'color': entry.color, 'quantity': speedFunc(label), 'label':label+ " " + speedType});
+            label += intervalValue;
+        });
+    }
+    else {
+        // convert distance units
+        imperialMaxValue = Math.round(metersToFeet(maxValue));
+        intervalValue = Math.trunc(imperialMaxValue/numClasses);
+        let label = 0.0;
+        colormap.forEach((entry) => {
+            newColormap.push({'color': entry.color, 'quantity': feetToMeters(label), 'label':label+ " ft"});
+            label += intervalValue;
+        });
+    }
+
+    style.rules[0].symbolizers[0].colorMap.colorMapEntries = newColormap;
+    //console.log(style);
+    return style;
+};
+*/

--- a/src/utils/map-utils.js
+++ b/src/utils/map-utils.js
@@ -319,6 +319,9 @@ export const knotsToMps = (s) => {
 export const mpsToKnots = (s) => {
     return s * 1.943844;
 };
+export const mphToKnots = (s) => {
+    return s / 1.15078;
+};
 
 // this functiom converts a style to imperial units
 // styles will always be saved locally in metric units


### PR DESCRIPTION
This PR adds a section to the settings panel to set unit of measurement to metric (default) or imperial.
The changes to the setting should mainly be visible in the legends and the ADCIRC raster settings functionality.
The units settings are persistent and will survive web page refresh.
One thing to note is that if the user switches between the metric and imperial settings, new default styles will be set for either one. All previously set ADCIRC raster setting will be lost and have to be reset.